### PR TITLE
Change example assets in the documentation

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -117,7 +117,7 @@ Screenlets are grouped in modules based on internal dependencies. Each module is
 
 Also, some screenlets can be used individually without the need to import an entire module. These include:
 
-- [`AssetListScreenlet`](Documentation/AssetListScreenlet.md): Shows a list of assets managed by [Liferay's Asset Framework](https://www.liferay.com/documentation/liferay-portal/6.2/development/-/ai/asset-framework-liferay-portal-6-2-dev-guide-06-en). This includes users, organizations, sites, and more.
+- [`AssetListScreenlet`](Documentation/AssetListScreenlet.md): Shows a list of assets managed by [Liferay's Asset Framework](https://www.liferay.com/documentation/liferay-portal/6.2/development/-/ai/asset-framework-liferay-portal-6-2-dev-guide-06-en). This includes web content, blog entries, documents and more.
 - [`WebContentDisplayScreenlet`](Documentation/WebContentDisplayScreenlet.md): Shows the HTML of web content. This screenlet uses the features avaiable in [Web Content Management](https://www.liferay.com/documentation/liferay-portal/6.2/user-guide/-/ai/web-content-management-liferay-portal-6-2-user-guide-02-en).
 
 Liferay Screens also contains *themes* that you can use to style screenlets. A list of these themes is presented next.


### PR DESCRIPTION
The existing examples of assets are not the best ones. These are better representation of what our users might expect when we talk about an asset list.
