### PR TITLE
Changing docs links to match reorg on LDN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This repository contains the Liferay Screens source code, in addition to several example projects that illustrate how Screens is used. For detailed instructions on developing mobile apps with Screens, see the [Screens documentation on the Liferay Developer Network (LDN)](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/mobile-apps-with-liferay-screens). 
+This repository contains the Liferay Screens source code, in addition to several example projects that illustrate how Screens is used. For detailed instructions on developing mobile apps with Screens, see the Screens documentation for [Android](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/android-apps-with-liferay-screens) and [iOS](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/ios-apps-with-liferay-screens) on the Liferay Developer Network (LDN). 
 
 Brief descriptions of this repository's contents are listed here:
 

--- a/android/README.md
+++ b/android/README.md
@@ -1,6 +1,6 @@
 # Liferay Screens for Android
 
-This folder contains the Liferay Screens for Android codebase, example projects, and additional View Sets. To learn how to use Screens for Android, see the [Screens documentation at the Liferay Developer Network (LDN)](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/mobile-apps-with-liferay-screens). 
+This folder contains the Liferay Screens for Android codebase, example projects, and additional View Sets. To learn how to use Screens for Android, see the [Screens for Android documentation at the Liferay Developer Network (LDN)](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/android-apps-with-liferay-screens). 
 
 This folder's contents are organized as follows:
 

--- a/android/samples/README.md
+++ b/android/samples/README.md
@@ -1,6 +1,6 @@
 # Liferay Screens for Android Samples
 
-This directory contains sample apps that demonstrate Liferay Screens for Android. You can refer to these apps, along with the [Liferay Screens documentation](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/mobile-apps-with-liferay-screens), to see how Screenlets and Views are used. 
+This directory contains sample apps that demonstrate Liferay Screens for Android. You can refer to these apps, along with the [Liferay Screens for Android documentation](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/android-apps-with-liferay-screens), to see how Screenlets and Views are used. 
 
 ## The Add Bookmark Screenlet
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,6 +1,6 @@
 # Liferay Screens for iOS
 
-This folder contains the Liferay Screens for iOS codebase and example projects. To learn how to use Screens for iOS, see the [Screens documentation at the Liferay Developer Network (LDN)](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/mobile-apps-with-liferay-screens). 
+This folder contains the Liferay Screens for iOS codebase and example projects. To learn how to use Screens for iOS, see the [Screens for iOS documentation at the Liferay Developer Network (LDN)](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/ios-apps-with-liferay-screens). 
 
 This folder's contents are organized as follows: 
 

--- a/ios/Samples/README.md
+++ b/ios/Samples/README.md
@@ -1,6 +1,6 @@
 # Liferay Screens Samples for iOS
 
-This directory contains sample apps that demonstrate Liferay Screens for iOS. Most examples are provided in both Objective-C and Swift. You can refer to these apps, along with the [Liferay Screens documentation](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/mobile-apps-with-liferay-screens), to see how Screenlets and Themes are used. 
+This directory contains sample apps that demonstrate Liferay Screens for iOS. Most examples are provided in both Objective-C and Swift. You can refer to these apps, along with the [Liferay Screens for iOS documentation](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/ios-apps-with-liferay-screens), to see how Screenlets and Themes are used. 
 
 ## The Showcase App
 


### PR DESCRIPTION
The Screens docs on dev.liferay.com were recently split into 2 new sections for Android and iOS. This PR changes the docs links to match these new sections.