### PR TITLE
LSR-658 Change locale in Android

### DIFF
--- a/android/library/core/src/main/java/com/liferay/mobile/screens/util/LiferayLocale.java
+++ b/android/library/core/src/main/java/com/liferay/mobile/screens/util/LiferayLocale.java
@@ -56,6 +56,9 @@ public class LiferayLocale {
 	public static void changeLocale(ContextThemeWrapper contextThemeWrapper, Locale newLocale) {
 		Resources res = contextThemeWrapper.getResources();
 		Configuration conf = res.getConfiguration();
+
+		Locale oldLocale = conf.locale;
+
 		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1) {
 			conf.setLocale(newLocale);
 		}
@@ -63,5 +66,7 @@ public class LiferayLocale {
 			conf.locale = newLocale;
 		}
 		res.updateConfiguration(conf, res.getDisplayMetrics());
+
+		EventBusUtil.post(new LocaleChanged(newLocale, oldLocale));
 	}
 }

--- a/android/library/core/src/main/java/com/liferay/mobile/screens/util/LiferayLocale.java
+++ b/android/library/core/src/main/java/com/liferay/mobile/screens/util/LiferayLocale.java
@@ -1,5 +1,10 @@
 package com.liferay.mobile.screens.util;
 
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import android.view.ContextThemeWrapper;
+
 import com.liferay.mobile.screens.context.LiferayScreensContext;
 
 import java.util.Locale;
@@ -42,5 +47,16 @@ public class LiferayLocale {
 
 	public static String getDefaultSupportedLocale() {
 		return getSupportedLocale(getDefaultLocale().getDisplayLanguage());
+	}
+	public static void changeLocale(ContextThemeWrapper contextThemeWrapper, Locale newLocale) {
+		Resources res = contextThemeWrapper.getResources();
+		Configuration conf = res.getConfiguration();
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1) {
+			conf.setLocale(newLocale);
+		}
+		else {
+			conf.locale = newLocale;
+		}
+		res.updateConfiguration(conf, res.getDisplayMetrics());
 	}
 }

--- a/android/library/core/src/main/java/com/liferay/mobile/screens/util/LiferayLocale.java
+++ b/android/library/core/src/main/java/com/liferay/mobile/screens/util/LiferayLocale.java
@@ -48,6 +48,11 @@ public class LiferayLocale {
 	public static String getDefaultSupportedLocale() {
 		return getSupportedLocale(getDefaultLocale().getDisplayLanguage());
 	}
+
+	/**
+	 * Method to change activity or application locale
+	 * An activity can be reloaded with a call to setContentView
+	 **/
 	public static void changeLocale(ContextThemeWrapper contextThemeWrapper, Locale newLocale) {
 		Resources res = contextThemeWrapper.getResources();
 		Configuration conf = res.getConfiguration();

--- a/android/library/core/src/main/java/com/liferay/mobile/screens/util/LocaleChanged.java
+++ b/android/library/core/src/main/java/com/liferay/mobile/screens/util/LocaleChanged.java
@@ -1,0 +1,25 @@
+package com.liferay.mobile.screens.util;
+
+import java.util.Locale;
+
+/**
+ * @author Javier Gamarra
+ */
+public class LocaleChanged {
+
+	public LocaleChanged(Locale newLocale, Locale oldLocale) {
+		_newLocale = newLocale;
+		_oldLocale = oldLocale;
+	}
+
+	public Locale getNewLocale() {
+		return _newLocale;
+	}
+
+	public Locale getOldLocale() {
+		return _oldLocale;
+	}
+
+	private final Locale _newLocale;
+	private final Locale _oldLocale;
+}


### PR DESCRIPTION
I'm afraid this isn't supported on Android :'(

There are few ways of changing the locale and none are done without reloading the activity/view (and losing all the state). The options we have are:
* Call the method provided from an activity/application and reload a full view calling setContentView (recommended). Will affect all the screenlets inside that activity. There isn't a more fine grained option.
* Call the method and recreate the activity, everything is the same as the previous method and the user sees a noticeable change.
* Reload each string one by one and retrieve the new localized one by changing all the locale of the app and setting it back after retrieving.