### PR TITLE
LSR-711 OAuth support for Mobile SDK 2.x

### DIFF
--- a/android/library/core/build.gradle
+++ b/android/library/core/build.gradle
@@ -57,9 +57,7 @@ dependencies {
 	compile 'de.greenrobot:eventbus:2.4.0'
 	compile 'com.squareup.picasso:picasso:2.5.2'
 
-	compile('com.liferay.mobile:liferay-android-oauth:+') {
-		exclude group: 'com.liferay.mobile', module: 'liferay-android-sdk'
-	}
+	compile 'com.liferay.mobile:liferay-android-oauth:1.3.0'
 
 	compile('com.pushtorefresh.storio:sqlite-annotations:1.7.0') {
 		exclude group: 'com.android.support', module: 'support-annotations'


### PR DESCRIPTION
New release (1.3.0) with a new custom adapter for the Request object of the Mobile SDK 2.0, see here: https://github.com/brunofarache/liferay-android-sdk-oauth/pull/7