### PR TITLE
LSR-984 Rename BookmarkListScreenlet comparator to obcClassName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+# 2.1.0
+
 <!-- Possible categories for the changes: Bugs, New features, Refactor, Documentation, Samples, Deprecated, Contributions -->
 ## Android
 
@@ -72,3 +74,16 @@ All notable changes to this project will be documented in this file.
 ### Samples
 * Created Showcase-ObjectiveC
 * Added file examples into Showcase-Swift: AudioDisplayScreenlet, VideoDisplayScreenlet and PdfDisplayScreenlet
+
+
+# Develop
+
+## Android
+
+### Refactor
+* Rename BookmarkListScreenlet comparator to obcClassName
+
+## iOS
+
+### Bugs
+* Allow developers override supported mime types in AssetDisplayScreenlet

--- a/android/samples/listbookmarkscreenlet/src/main/java/com/liferay/mobile/screens/listbookmark/BookmarkListScreenlet.java
+++ b/android/samples/listbookmarkscreenlet/src/main/java/com/liferay/mobile/screens/listbookmark/BookmarkListScreenlet.java
@@ -27,7 +27,6 @@ import com.liferay.mobile.screens.context.LiferayServerContext;
 public class BookmarkListScreenlet extends BaseListScreenlet<Bookmark, BookmarkListInteractor> {
 
 	private long folderId;
-	private String comparator;
 
 	public BookmarkListScreenlet(Context context) {
 		super(context);
@@ -58,7 +57,6 @@ public class BookmarkListScreenlet extends BaseListScreenlet<Bookmark, BookmarkL
 			context.getTheme().obtainStyledAttributes(attributes, R.styleable.BookmarkListScreenlet, 0, 0);
 		groupId = typedArray.getInt(R.styleable.BookmarkListScreenlet_groupId, (int) LiferayServerContext.getGroupId());
 		folderId = typedArray.getInt(R.styleable.BookmarkListScreenlet_folderId, 0);
-		comparator = typedArray.getString(R.styleable.BookmarkListScreenlet_comparator);
 		typedArray.recycle();
 
 		return super.createScreenletView(context, attributes);
@@ -69,7 +67,7 @@ public class BookmarkListScreenlet extends BaseListScreenlet<Bookmark, BookmarkL
 
 		((BookmarkListListener) getListener()).interactorCalled();
 
-		interactor.start(folderId, comparator);
+		interactor.start(folderId, obcClassName);
 	}
 
 	@Override

--- a/android/samples/listbookmarkscreenlet/src/main/res/values/bookmark_attrs.xml
+++ b/android/samples/listbookmarkscreenlet/src/main/res/values/bookmark_attrs.xml
@@ -3,7 +3,6 @@
 	<declare-styleable name="BookmarkListScreenlet">
 		<attr name="groupId"/>
 		<attr name="folderId"/>
-		<attr format="string" name="comparator"/>
 		<attr name="cachePolicy"/>
 		<attr name="obcClassName"/>
 	</declare-styleable>

--- a/android/samples/test-app/src/main/res/layout/activity_list_bookmarks.xml
+++ b/android/samples/test-app/src/main/res/layout/activity_list_bookmarks.xml
@@ -16,7 +16,7 @@
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
 		app:cachePolicy="REMOTE_FIRST"
-		app:comparator="com.liferay.bookmarks.util.comparator.EntryURLComparator"
+		app:obcClassName="com.liferay.bookmarks.util.comparator.EntryURLComparator"
 		app:folderId="@string/liferay_bookmark_folder"
 		app:layoutId="@layout/list_bookmarks"
 		/>


### PR DESCRIPTION
Every list screenlet has the optional comparator attribute to sort the results and by default is named: obcClassName.