### PR TITLE
LSR-1021 iOS changes for Xamarin.iOS binding (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this project will be documented in this file.
 * AssetDisplayScreenlet uses FileDisplayScreenlet for ppt, xls and doc files
 * Allow developers override injected CSS in WebContentDisplayScreenlet
 * Add PortletDisplayScreenlet
+* Add name to classes annotated with @objc for Xamarin solutions
+* Remove module name in default views for Xamarin solutions
 
 ### Refactor
 * Migrate from UIWebView to WKWebView

--- a/ios/Framework/Core/Asset/DisplayScreenlet/AssetDisplayScreenlet.swift
+++ b/ios/Framework/Core/Asset/DisplayScreenlet/AssetDisplayScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The AssetDisplayScreenletDelegate protocol defines some methods that you use to manage the
 /// AssetDisplayScreenlet events. All of them are optional.
-@objc public protocol AssetDisplayScreenletDelegate: BaseScreenletDelegate {
+@objc(AssetDisplayScreenletDelegate)
+public protocol AssetDisplayScreenletDelegate: BaseScreenletDelegate {
 
 	///  Called when the screenlet receives the asset.
 	///
@@ -59,6 +60,7 @@ import UIKit
 /// currently display Documents and Media files (DLFileEntry images, videos, audio files, and PDFs),
 /// blogs entries (BlogsEntry) and web content articles (WebContent). 
 /// Asset Display Screenlet can also display your custom asset types.
+@objc(AssetDisplayScreenlet)
 open class AssetDisplayScreenlet: BaseScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/Asset/DisplayScreenlet/AssetDisplayViewModel.swift
+++ b/ios/Framework/Core/Asset/DisplayScreenlet/AssetDisplayViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol AssetDisplayViewModel {
+@objc(AssetDisplayViewModel)
+public protocol AssetDisplayViewModel {
 
 	/// Asset to be displayed.
 	var asset: Asset? { get set }

--- a/ios/Framework/Core/Asset/ListScreenlet/AssetListScreenlet.swift
+++ b/ios/Framework/Core/Asset/ListScreenlet/AssetListScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The AssetListScreenletDelegate protocol defines some methods that you use to manage the
 /// AssetListScreenlet events. All of them are optional.
-@objc public protocol AssetListScreenletDelegate: BaseScreenletDelegate {
+@objc(AssetListScreenletDelegate)
+public protocol AssetListScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when a page of assets is received. Note that this method may be called 
 	/// more than once; one call for each page received.
@@ -50,6 +51,7 @@ import UIKit
 /// For example, you can use the Screenlet to show a scrollable collection of assets. 
 /// It also implements [fluent pagination](http://www.iosnomad.com/blog/2014/4/21/fluent-pagination) 
 /// with configurable page size.
+@objc(AssetListScreenlet)
 open class AssetListScreenlet: BaseListScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/Auth/Common/BasicAuthBased.swift
+++ b/ios/Framework/Core/Auth/Common/BasicAuthBased.swift
@@ -13,14 +13,16 @@
  */
 import UIKit
 
-@objc public protocol AnonymousBasicAuthType {
+@objc(AnonymousBasicAuthType)
+public protocol AnonymousBasicAuthType {
 
 	var anonymousApiUserName: String? { get set }
 	var anonymousApiPassword: String? { get set }
 
 }
 
-@objc public protocol BasicAuthBasedType {
+@objc(BasicAuthBasedType)
+public protocol BasicAuthBasedType {
 
 	var basicAuthMethod: String? { get set }
 

--- a/ios/Framework/Core/Auth/ForgotPasswordScreenlet/ForgotPasswordScreenlet.swift
+++ b/ios/Framework/Core/Auth/ForgotPasswordScreenlet/ForgotPasswordScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The ForgotPasswordScreenletDelegate protocol defines some methods that you use to manage the
 /// ForgotPasswordScreenlet events. All of them are optional.
-@objc public protocol ForgotPasswordScreenletDelegate: BaseScreenletDelegate {
+@objc(ForgotPasswordScreenletDelegate)
+public protocol ForgotPasswordScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when a password reset email is successfully sent.
 	///
@@ -43,6 +44,7 @@ import UIKit
 ///	* Email address
 ///	* Screen name
 ///	* User id
+@objc(ForgotPasswordScreenlet)
 open class ForgotPasswordScreenlet: BaseScreenlet, BasicAuthBasedType, AnonymousBasicAuthType {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/Auth/ForgotPasswordScreenlet/ForgotPasswordViewModel.swift
+++ b/ios/Framework/Core/Auth/ForgotPasswordScreenlet/ForgotPasswordViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol ForgotPasswordViewModel: BasicAuthBasedType {
+@objc(ForgotPasswordViewModel)
+public protocol ForgotPasswordViewModel: BasicAuthBasedType {
 
 	/// Login username: can be email address, userId or screen name.
 	var userName: String? { get set }

--- a/ios/Framework/Core/Auth/LoginScreenlet/LoginScreenlet.swift
+++ b/ios/Framework/Core/Auth/LoginScreenlet/LoginScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The LoginScreenletDelegate protocol defines some methods that you use to manage the
 /// LoginScreenlet events. All of them are optional.
-@objc public protocol LoginScreenletDelegate: BaseScreenletDelegate {
+@objc(LoginScreenletDelegate)
+public protocol LoginScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when login successfully completes.
 	/// The user attributes are passed as a dictionary of keys (String or NSStrings) 
@@ -55,6 +56,7 @@ import UIKit
 
 }
 
+@objc(LoginScreenlet)
 open class LoginScreenlet: BaseScreenlet, BasicAuthBasedType {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/Auth/LoginScreenlet/LoginViewModel.swift
+++ b/ios/Framework/Core/Auth/LoginScreenlet/LoginViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol LoginViewModel: BasicAuthBasedType {
+@objc(LoginViewModel)
+public protocol LoginViewModel: BasicAuthBasedType {
 
 	/// Login username: can be email address, userId or screen name.
 	var userName: String? { get set }

--- a/ios/Framework/Core/Auth/SignUpScreenlet/SignUpScreenlet.swift
+++ b/ios/Framework/Core/Auth/SignUpScreenlet/SignUpScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The SignUpScreenletDelegate protocol defines some methods that you use to manage the
 /// SignUpScreenlet events. All of them are optional.
-@objc public protocol SignUpScreenletDelegate: BaseScreenletDelegate {
+@objc(SignUpScreenletDelegate)
+public protocol SignUpScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when sign up successfully completes.
 	/// The user attributes are passed as a dictionary of keys (String or NSStrings)
@@ -42,6 +43,7 @@ import UIKit
 /// can become a new user in your portal. You can also use this Screenlet to save the credentials 
 /// of the new user in their keychain. This enables auto login for future sessions. The Screenlet 
 /// also supports navigation of form fields from the keyboard of the user’s device.
+@objc(SignUpScreenlet)
 open class SignUpScreenlet: BaseScreenlet, AnonymousBasicAuthType {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/Auth/SignUpScreenlet/SignUpViewModel.swift
+++ b/ios/Framework/Core/Auth/SignUpScreenlet/SignUpViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol SignUpViewModel {
+@objc(SignUpViewModel)
+public protocol SignUpViewModel {
 
 	/// User email address.
 	var emailAddress: String? { get set }

--- a/ios/Framework/Core/Auth/UserPortraitScreenlet/UserPortraitScreenlet.swift
+++ b/ios/Framework/Core/Auth/UserPortraitScreenlet/UserPortraitScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The UserPortraitScreenletDelegate protocol defines some methods that you use to manage the 
 /// UserPortraitScreenlet events. All of them are optional.
-@objc public protocol UserPortraitScreenletDelegate: BaseScreenletDelegate {
+@objc(UserPortraitScreenletDelegate)
+public protocol UserPortraitScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when an image is received from the server. You can then apply image filters 
 	/// (grayscale, for example) and return the new image. You can return the original image 
@@ -58,6 +59,7 @@ import UIKit
 
 /// The UserPortraitScreenlet shows the user’s portrait from Liferay instance.
 /// If the user doesn’t have a portrait configured, a default placeholder image is shown.
+@objc(UserPortraitScreenlet)
 open class UserPortraitScreenlet: BaseScreenlet {
 
 	// MARK: Class properties

--- a/ios/Framework/Core/Auth/UserPortraitScreenlet/UserPortraitViewModel.swift
+++ b/ios/Framework/Core/Auth/UserPortraitScreenlet/UserPortraitViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol UserPortraitViewModel {
+@objc(UserPortraitViewModel)
+public protocol UserPortraitViewModel {
 
 	/// User portrait image to be displayed.
 	var image: UIImage? { get set }

--- a/ios/Framework/Core/Base/BaseListScreenlet/BaseListScreenlet.swift
+++ b/ios/Framework/Core/Base/BaseListScreenlet/BaseListScreenlet.swift
@@ -15,6 +15,7 @@ import UIKit
 
 /// BaseListScreenlet is the base class from which all list Screenlet classes must inherit.
 /// A screenlet is the container for a screenlet view.
+@objc(BaseListScreenlet)
 open class BaseListScreenlet: BaseScreenlet {
 
 	// MARK: Class properties

--- a/ios/Framework/Core/Base/BaseScreenlet.swift
+++ b/ios/Framework/Core/Base/BaseScreenlet.swift
@@ -17,7 +17,8 @@ import QuartzCore
 
 /// The BaseScreenletDelegate protocol defines one method that you use to manage the
 /// BaseScreenlet events. This method is optional.
-@objc public protocol BaseScreenletDelegate: NSObjectProtocol {
+@objc(BaseScreenletDelegate)
+public protocol BaseScreenletDelegate: NSObjectProtocol {
 
 	/// Called when we want to return a custom interactor (use case) with the given action name.
 	///
@@ -34,6 +35,7 @@ import QuartzCore
 
 /// BaseScreenlet is the base class from which all Screenlet classes must inherit.
 /// A screenlet is the container for a screenlet view.
+@objc(BaseScreenlet)
 @IBDesignable open class BaseScreenlet: UIView {
 
 	// MARK: Static properties

--- a/ios/Framework/Core/Base/BaseScreenletView.swift
+++ b/ios/Framework/Core/Base/BaseScreenletView.swift
@@ -16,6 +16,7 @@ import UIKit
 /*!
  * BaseScreenletView is the base class from which all Screenlet's View classes must inherit.
  */
+@objc(BaseScreenletView)
 open class BaseScreenletView: UIView, UITextFieldDelegate {
 
 	open weak var screenlet: BaseScreenlet?

--- a/ios/Framework/Core/Base/Interactor.swift
+++ b/ios/Framework/Core/Base/Interactor.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc open class Interactor: NSObject {
+@objc(Interactor)
+open class Interactor: NSObject {
 
 	open var actionName: String?
 

--- a/ios/Framework/Core/Base/ProgressPresenter.swift
+++ b/ios/Framework/Core/Base/ProgressPresenter.swift
@@ -13,7 +13,9 @@
  */
 import Foundation
 
-@objc public protocol ProgressPresenter {
+
+@objc(ProgressPresenter)
+public protocol ProgressPresenter {
 
 	func showHUDInView(_ view: UIView,
 		message: String?,

--- a/ios/Framework/Core/BlogsDisplay/BlogsDisplayViewModel.swift
+++ b/ios/Framework/Core/BlogsDisplay/BlogsDisplayViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol BlogsDisplayViewModel {
+@objc(BlogsDisplayViewModel)
+public protocol BlogsDisplayViewModel {
 
 	/// Blogs entry to be displayed.
 	var blogsEntry: BlogsEntry? { get set }

--- a/ios/Framework/Core/BlogsDisplay/BlogsEntryDisplayScreenlet.swift
+++ b/ios/Framework/Core/BlogsDisplay/BlogsEntryDisplayScreenlet.swift
@@ -15,7 +15,8 @@ import Foundation
 
 /// The BlogsEntryDisplayScreenletDelegate protocol defines some methods that you use to manage the
 /// BlogsEntryDisplayScreenlet events. All of them are optional.
-@objc public protocol BlogsEntryDisplayScreenletDelegate: BaseScreenletDelegate {
+@objc(BlogsEntryDisplayScreenletDelegate)
+public protocol BlogsEntryDisplayScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when the Screenlet receives the BlogsEntry object.
 	///
@@ -37,6 +38,7 @@ import Foundation
 
 /// Blogs Entry Display Screenlet displays a single blog entry. Image Display Screenlet renders any
 /// header image the blogs entry may have.
+@objc(BlogsEntryDisplayScreenlet)
 open class BlogsEntryDisplayScreenlet: BaseScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/Comment/Add/CommentAddScreenlet.swift
+++ b/ios/Framework/Core/Comment/Add/CommentAddScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The CommentAddScreenletDelegate protocol defines some methods that you use to manage the
 /// CommentAddScreenlet events. All of them are optional.
-@objc public protocol CommentAddScreenletDelegate: BaseScreenletDelegate {
+@objc(CommentAddScreenletDelegate)
+public protocol CommentAddScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when the screenlet adds a comment.
 	///
@@ -54,6 +55,7 @@ import UIKit
 }
 
 /// Comment Add Screenlet can add a comment to an asset in a Liferay instance.
+@objc(CommentAddScreenlet)
 open class CommentAddScreenlet: BaseScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/Comment/Add/CommentAddViewModel.swift
+++ b/ios/Framework/Core/Comment/Add/CommentAddViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol CommentAddViewModel {
+@objc(CommentAddViewModel)
+public protocol CommentAddViewModel {
 
 	/// Comment content for new entry.
 	var body: String { get set }

--- a/ios/Framework/Core/Comment/Display/CommentDisplayScreenlet.swift
+++ b/ios/Framework/Core/Comment/Display/CommentDisplayScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The CommentDisplayScreenletDelegate protocol defines some methods that you use to manage the
 /// CommentDisplayScreenlet events. All of them are optional.
-@objc public protocol CommentDisplayScreenletDelegate: BaseScreenletDelegate {
+@objc(CommentDisplayScreenletDelegate)
+public protocol CommentDisplayScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when the screenlet loads the comment.
 	///
@@ -74,6 +75,7 @@ import UIKit
 
 /// Comment Display Screenlet can show one comment of an asset in a Liferay instance. It also lets 
 /// the user update or delete the comment.
+@objc(CommentDisplayScreenlet)
 open class CommentDisplayScreenlet: BaseScreenlet {
 
 	// MARK: Static properties

--- a/ios/Framework/Core/Comment/Display/CommentDisplayViewModel.swift
+++ b/ios/Framework/Core/Comment/Display/CommentDisplayViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol CommentDisplayViewModel {
+@objc(CommentDisplayViewModel)
+public protocol CommentDisplayViewModel {
 
 	/// Comment entry to be displayed.
 	var comment: Comment? { get set }

--- a/ios/Framework/Core/Comment/List/CommentListScreenlet.swift
+++ b/ios/Framework/Core/Comment/List/CommentListScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The CommentListScreenletDelegate protocol defines some methods that you use to manage the
 /// CommentListScreenlet events. All of them are optional.
-@objc public protocol CommentListScreenletDelegate: BaseScreenletDelegate {
+@objc(CommentListScreenletDelegate)
+public protocol CommentListScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when the screenlet receives the comments.
 	///
@@ -82,6 +83,7 @@ import UIKit
 
 /// Comment List Screenlet can list all the comments of an asset in a Liferay instance. It also 
 // lets the user update or delete comments.
+@objc(CommentListScreenlet)
 open class CommentListScreenlet: BaseListScreenlet, CommentDisplayScreenletDelegate {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/Comment/List/CommentListViewModel.swift
+++ b/ios/Framework/Core/Comment/List/CommentListViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol CommentListViewModel {
+@objc(CommentListViewModel)
+public protocol CommentListViewModel {
 
 	/// Call this method to add a new asset comment.
 	///

--- a/ios/Framework/Core/DDL/FormScreenlet/DDLFormScreenlet.swift
+++ b/ios/Framework/Core/DDL/FormScreenlet/DDLFormScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The DDLFormScreenletDelegate protocol defines some methods that you use to manage the
 /// DDLFormScreenlet events. All of them are optional.
-@objc public protocol DDLFormScreenletDelegate: BaseScreenletDelegate {
+@objc(DDLFormScreenletDelegate)
+public protocol DDLFormScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when the form is loaded. The second parameter (record) 
 	/// contains only field definitions.
@@ -123,6 +124,7 @@ import UIKit
 /// * Required values and validation for fields can be used.
 /// * Users can traverse the form fields from the keyboard.
 /// * Supports i18n in record values and labels.
+@objc(DDLFormScreenlet)
 open class DDLFormScreenlet: BaseScreenlet {
 
 	fileprivate enum UploadStatus {

--- a/ios/Framework/Core/DDL/FormScreenlet/DDLFormViewModel.swift
+++ b/ios/Framework/Core/DDL/FormScreenlet/DDLFormViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol DDLFormViewModel {
+@objc(DDLFormViewModel)
+public protocol DDLFormViewModel {
 
 	/// Show or hide the submit button of the form.
 	var showSubmitButton: Bool { get set }

--- a/ios/Framework/Core/DDL/ListScreenlet/DDLListScreenlet.swift
+++ b/ios/Framework/Core/DDL/ListScreenlet/DDLListScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The DDLListScreenletDelegate protocol defines some methods that you use to manage the
 /// DDLListScreenlet events. All of them are optional.
-@objc public protocol DDLListScreenletDelegate: BaseScreenletDelegate {
+@objc(DDLListScreenletDelegate)
+public protocol DDLListScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when a page of contents is received. Note that this method may be called 
 	/// more than once; one call for each page received.
@@ -50,6 +51,7 @@ import UIKit
 /// * Implements fluent pagination with configurable page size.
 /// * Allows filtering of records by creator.
 /// * Supports i18n in record values.
+@objc(DDLListScreenlet)
 open class DDLListScreenlet: BaseListScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/DDL/ListScreenlet/DDLListViewModel.swift
+++ b/ios/Framework/Core/DDL/ListScreenlet/DDLListViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol DDLListViewModel {
+@objc(DDLListViewModel)
+public protocol DDLListViewModel {
 
 	/// Gets all the labels of the different fields of the form.
 	var labelFields: [String] { get set }

--- a/ios/Framework/Core/FileDisplay/AudioDisplayScreenlet.swift
+++ b/ios/Framework/Core/FileDisplay/AudioDisplayScreenlet.swift
@@ -15,6 +15,7 @@ import Foundation
 
 /// Audio Display Screenlet displays an audio file from a Liferay instance’s Documents and Media 
 ///Library.
+@objc(AudioDisplayScreenlet)
 open class AudioDisplayScreenlet: FileDisplayScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/FileDisplay/FileDisplayScreenlet.swift
+++ b/ios/Framework/Core/FileDisplay/FileDisplayScreenlet.swift
@@ -15,7 +15,8 @@ import Foundation
 
 /// The FileDisplayScreenletDelegate protocol defines some methods that you use to manage the
 /// FileDisplayScreenlet events. All of them are optional.
-@objc public protocol FileDisplayScreenletDelegate: BaseScreenletDelegate {
+@objc(FileDisplayScreenletDelegate)
+public protocol FileDisplayScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when the screenlet receives the file.
 	///
@@ -36,6 +37,7 @@ import Foundation
 /// File Display Screenlet shows a single file from a Liferay Portal instance’s Documents and Media
 /// Library. Use this Screenlet to display file types not covered by the other display Screenlets 
 /// (e.g., DOC, PPT, XLS).
+@objc(FileDisplayScreenlet)
 open class FileDisplayScreenlet: BaseScreenlet {
 
 	// MARK: Static properties

--- a/ios/Framework/Core/FileDisplay/FileDisplayViewModel.swift
+++ b/ios/Framework/Core/FileDisplay/FileDisplayViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol FileDisplayViewModel {
+@objc(FileDisplayViewModel)
+public protocol FileDisplayViewModel {
 
 	/// File URL to be displayed.
 	var url: URL? { get set }

--- a/ios/Framework/Core/FileDisplay/ImageDisplayScreenlet.swift
+++ b/ios/Framework/Core/FileDisplay/ImageDisplayScreenlet.swift
@@ -15,6 +15,7 @@ import Foundation
 
 /// Image Display Screenlet displays an image file from a Liferay instance’s Documents and Media 
 /// Library.
+@objc(ImageDisplayScreenlet)
 open class ImageDisplayScreenlet: FileDisplayScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/FileDisplay/ImageDisplayViewModel.swift
+++ b/ios/Framework/Core/FileDisplay/ImageDisplayViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol ImageDisplayViewModel: FileDisplayViewModel {
+@objc(ImageDisplayViewModel)
+public protocol ImageDisplayViewModel: FileDisplayViewModel {
 
 	/// Image mode for the screenlet image. See UIViewContentMode enum for
 	/// knowing all the posible modes.

--- a/ios/Framework/Core/FileDisplay/PdfDisplayScreenlet.swift
+++ b/ios/Framework/Core/FileDisplay/PdfDisplayScreenlet.swift
@@ -14,6 +14,7 @@
 import Foundation
 
 /// PDF Display Screenlet displays a PDF file from a Liferay Instance’s Documents and Media Library.
+@objc(PdfDisplayScreenlet)
 open class PdfDisplayScreenlet: FileDisplayScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/FileDisplay/VideoDisplayScreenlet.swift
+++ b/ios/Framework/Core/FileDisplay/VideoDisplayScreenlet.swift
@@ -15,6 +15,7 @@ import Foundation
 
 ///Video Display Screenlet displays a video file from a Liferay instance’s Documents and Media 
 /// Library.
+@objc(VideoDisplayScreenlet)
 open class VideoDisplayScreenlet: FileDisplayScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/ImageGalleryScreenlet/ImageGalleryScreenlet.swift
+++ b/ios/Framework/Core/ImageGalleryScreenlet/ImageGalleryScreenlet.swift
@@ -16,7 +16,8 @@ import Kingfisher
 
 /// The ImageGalleryScreenletDelegate protocol defines some methods that you use to manage the
 /// ImageGalleryScreenlet events. All of them are optional.
-@objc public protocol ImageGalleryScreenletDelegate: BaseScreenletDelegate {
+@objc(ImageGalleryScreenletDelegate)
+public protocol ImageGalleryScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when a page of contents is received.
 	/// Note that this method may be called more than once: one call for each page received.
@@ -116,6 +117,7 @@ import Kingfisher
 /// the same folder. The Screenlet implements [fluent pagination]
 /// (http://www.iosnomad.com/blog/2014/4/21/fluent-pagination) with configurable page size, 
 /// and supports i18n in asset values.
+@objc(ImageGalleryScreenlet)
 open class ImageGalleryScreenlet: BaseListScreenlet {
 
 	// MARK: Static properties

--- a/ios/Framework/Core/ImageGalleryScreenlet/ImageGalleryViewModel.swift
+++ b/ios/Framework/Core/ImageGalleryScreenlet/ImageGalleryViewModel.swift
@@ -13,7 +13,8 @@
  */
 import Foundation
 
-@objc public protocol ImageGalleryViewModel {
+@objc(ImageGalleryViewModel)
+public protocol ImageGalleryViewModel {
 
 	/// Total images of the image gallery.
 	var totalEntries: Int { get }

--- a/ios/Framework/Core/Rating/RatingScreenlet.swift
+++ b/ios/Framework/Core/Rating/RatingScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The RatingScreenletDelegate protocol defines some methods that you use to manage the
 /// RatingScreenlet events. All of them are optional.
-@objc public protocol RatingScreenletDelegate: BaseScreenletDelegate {
+@objc(RatingScreenletDelegate)
+public protocol RatingScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when the ratings are received.
 	///
@@ -53,6 +54,7 @@ import UIKit
 
 ///Rating Screenlet shows an asset’s rating. It also lets users update or delete the rating. 
 /// This Screenlet comes with different Themes that display ratings as thumbs, stars, and emojis.
+@objc(RatingScreenlet)
 open class RatingScreenlet: BaseScreenlet {
 
 	// MARK: Static properties

--- a/ios/Framework/Core/Rating/RatingViewModel.swift
+++ b/ios/Framework/Core/Rating/RatingViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol RatingViewModel {
+@objc(RatingViewModel)
+public protocol RatingViewModel {
 
 	/// Number of possible rating values available for the user in the view.
 	var defaultRatingsGroupCount: Int32 { get }

--- a/ios/Framework/Core/WebContent/DisplayScreenlet/WebContentDisplayScreenlet.swift
+++ b/ios/Framework/Core/WebContent/DisplayScreenlet/WebContentDisplayScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The WebContentDisplayScreenletDelegate protocol defines some methods that you use to manage the
 /// WebContentDisplayScreenlet events. All of them are optional.
-@objc public protocol WebContentDisplayScreenletDelegate: BaseScreenletDelegate {
+@objc(WebContentDisplayScreenletDelegate)
+public protocol WebContentDisplayScreenletDelegate: BaseScreenletDelegate {
 
 	///  Called when the web content’s HTML is received.
 	///
@@ -48,6 +49,7 @@ import UIKit
 /// The Web Content Display Screenlet shows web content elements in your app, rendering the inner 
 /// HTML of the web content. The Screenlet also supports i18n, rendering contents differently 
 /// depending on the device’s current locale.
+@objc(WebContentDisplayScreenlet)
 open class WebContentDisplayScreenlet: BaseScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/Core/WebContent/DisplayScreenlet/WebContentDisplayViewModel.swift
+++ b/ios/Framework/Core/WebContent/DisplayScreenlet/WebContentDisplayViewModel.swift
@@ -13,7 +13,8 @@
  */
 import UIKit
 
-@objc public protocol WebContentDisplayViewModel {
+@objc(WebContentDisplayViewModel)
+public protocol WebContentDisplayViewModel {
 
 	/// WebContent html to be displayed.
 	var htmlContent: String? { get set }

--- a/ios/Framework/Core/WebContent/ListScreenlet/WebContentListScreenlet.swift
+++ b/ios/Framework/Core/WebContent/ListScreenlet/WebContentListScreenlet.swift
@@ -15,7 +15,8 @@ import UIKit
 
 /// The WebContentListScreenletDelegate protocol defines some methods that you use to manage the
 /// WebContentListScreenlet events. All of them are optional.
-@objc public protocol WebContentListScreenletDelegate: BaseScreenletDelegate {
+@objc(WebContentListScreenletDelegate)
+public protocol WebContentListScreenletDelegate: BaseScreenletDelegate {
 
 	/// Called when a page of contents is received.
 	/// Note that this method may be called more than once: one call for each page received.
@@ -50,6 +51,7 @@ import UIKit
 /// show both basic and [structured web content]
 /// (https://dev.liferay.com/discover/portal/-/knowledge_base/7-0/designing-uniform-content). The Screenlet also 
 /// implements fluent pagination with configurable page size, and supports i18n in asset values.
+@objc(WebContentListScreenlet)
 open class WebContentListScreenlet: BaseListScreenlet {
 
 	// MARK: Inspectables

--- a/ios/Framework/LiferayScreens.xcodeproj/project.pbxproj
+++ b/ios/Framework/LiferayScreens.xcodeproj/project.pbxproj
@@ -85,7 +85,7 @@
 		0B2180341D6C508200A23690 /* DDMFieldString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2180031D6C4F6F00A23690 /* DDMFieldString.swift */; };
 		0B2180351D6C508200A23690 /* DDMFieldStringWithOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2180041D6C4F6F00A23690 /* DDMFieldStringWithOptions.swift */; };
 		0B2180361D6C508200A23690 /* DDMFieldUntyped.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2180051D6C4F6F00A23690 /* DDMFieldUntyped.swift */; };
-		0B2677DE1D3D1E5700FDFC5B /* (null) in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
+		0B2677DE1D3D1E5700FDFC5B /* BuildFile in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
 		0B2BBE731DC3670800010F30 /* default-preview-imagegallery@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0B2BBE721DC3670800010F30 /* default-preview-imagegallery@2x.png */; };
 		0B2BBE761DC3699C00010F30 /* default-list-preview-imagegallery@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0B2BBE741DC3699C00010F30 /* default-list-preview-imagegallery@2x.png */; };
 		0B2BBE771DC3699C00010F30 /* default-slideshow-preview-imagegallery@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0B2BBE751DC3699C00010F30 /* default-slideshow-preview-imagegallery@2x.png */; };
@@ -2506,7 +2506,7 @@
 				887E069B1C6A4DF800CA3807 /* LRScreensjournalarticleService_v70.h in Headers */,
 				887E06971C6A4DF800CA3807 /* LRScreensassetentryService_v70.h in Headers */,
 				88DE2AA21AD3ED6800714701 /* LiferayScreensFrameworkConfig.h in Headers */,
-				0B2677DE1D3D1E5700FDFC5B /* (null) in Headers */,
+				0B2677DE1D3D1E5700FDFC5B /* BuildFile in Headers */,
 				887E05511C6A4DB000CA3807 /* LRScreensjournalarticleService_v62.h in Headers */,
 				0BFE283A1D87E13300261A66 /* LRScreenscommentService_v70.h in Headers */,
 			);
@@ -2773,7 +2773,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		B146147EA81C5DE8F28EACDF /* [CP] Copy Pods Resources */ = {
@@ -2818,7 +2818,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/ios/Framework/Themes/Default/Asset/DisplayScreenlet/AssetDisplayView_default.swift
+++ b/ios/Framework/Themes/Default/Asset/DisplayScreenlet/AssetDisplayView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(AssetDisplayView_default)
 open class AssetDisplayView_default: BaseScreenletView, AssetDisplayViewModel {
 
 	open override var progressMessages: [String : ProgressMessages] {

--- a/ios/Framework/Themes/Default/Asset/ListScreenlet/AssetListView_default.swift
+++ b/ios/Framework/Themes/Default/Asset/ListScreenlet/AssetListView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(AssetListView_default)
 open class AssetListView_default: AssetListTableView {
 
 	// MARK: BaseScreenletView

--- a/ios/Framework/Themes/Default/Auth/ForgotPasswordScreenlet/ForgotPasswordView_default.swift
+++ b/ios/Framework/Themes/Default/Auth/ForgotPasswordScreenlet/ForgotPasswordView_default.swift
@@ -18,9 +18,9 @@ open class ForgotPasswordView_default: BaseScreenletView, ForgotPasswordViewMode
 
 	// MARK: Outlets
 
-	@IBOutlet open var userNameField: UITextField?
+	@IBOutlet open weak var userNameField: UITextField?
 
-	@IBOutlet open var requestPasswordButton: UIButton?
+	@IBOutlet open weak var requestPasswordButton: UIButton?
 
 	override open var progressMessages: [String:ProgressMessages] {
 		return [

--- a/ios/Framework/Themes/Default/Auth/ForgotPasswordScreenlet/ForgotPasswordView_default.swift
+++ b/ios/Framework/Themes/Default/Auth/ForgotPasswordScreenlet/ForgotPasswordView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(ForgotPasswordView_default)
 open class ForgotPasswordView_default: BaseScreenletView, ForgotPasswordViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/Auth/ForgotPasswordScreenlet/ForgotPasswordView_default.xib
+++ b/ios/Framework/Themes/Default/Auth/ForgotPasswordScreenlet/ForgotPasswordView_default.xib
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ForgotPasswordView_default" customModule="LiferayScreens">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ForgotPasswordView_default">
             <rect key="frame" x="0.0" y="0.0" width="296" height="120"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <textField opaque="NO" clipsSubviews="YES" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lQM-e9-Lbg" customClass="DefaultTextField" customModule="LiferayScreens">
+                    <rect key="frame" x="0.0" y="0.0" width="296" height="50"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="AJb-il-4Jl"/>
                     </constraints>
@@ -20,6 +24,7 @@
                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
                 </textField>
                 <button opaque="NO" tag="2" contentMode="scaleToFill" restorationIdentifier="login-action" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DAI-a1-Iln">
+                    <rect key="frame" x="0.0" y="70" width="296" height="50"/>
                     <color key="backgroundColor" red="0.083623558282852173" green="0.66497266292572021" blue="0.84832382202148438" alpha="0.87" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="LMr-yV-neH"/>

--- a/ios/Framework/Themes/Default/Auth/LoginScreenlet/LoginView_default.swift
+++ b/ios/Framework/Themes/Default/Auth/LoginScreenlet/LoginView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(LoginView_default)
 open class LoginView_default: BaseScreenletView, LoginViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/Auth/LoginScreenlet/LoginView_default.xib
+++ b/ios/Framework/Themes/Default/Auth/LoginScreenlet/LoginView_default.xib
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="LoginView_default" customModule="LiferayScreens">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="LoginView_default">
             <rect key="frame" x="0.0" y="0.0" width="228" height="184"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <button hidden="YES" opaque="NO" tag="4" contentMode="scaleToFill" restorationIdentifier="oauth-action" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IUm-aw-kAf">
+                    <rect key="frame" x="0.0" y="70" width="228" height="44"/>
                     <color key="backgroundColor" red="0.083623558282852173" green="0.66497266292572021" blue="0.84832382202148438" alpha="0.87" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="b3f-Ri-XlM"/>
@@ -31,8 +35,10 @@
                     </state>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QyT-Vh-USo" userLabel="Basic Auth View">
+                    <rect key="frame" x="0.0" y="0.0" width="228" height="184"/>
                     <subviews>
                         <textField opaque="NO" clipsSubviews="YES" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lQM-e9-Lbg" customClass="DefaultTextField" customModule="LiferayScreens">
+                            <rect key="frame" x="0.0" y="0.0" width="228" height="50"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="50" id="kR7-TD-EWl"/>
                             </constraints>
@@ -43,6 +49,7 @@
                             </connections>
                         </textField>
                         <textField opaque="NO" clipsSubviews="YES" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XBk-dU-LXI" customClass="DefaultTextField" customModule="LiferayScreens">
+                            <rect key="frame" x="0.0" y="58" width="228" height="51"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="51" id="CNl-Mk-h8J"/>
                             </constraints>
@@ -56,6 +63,7 @@
                             </connections>
                         </textField>
                         <button opaque="NO" tag="3" contentMode="scaleToFill" restorationIdentifier="login-action" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kq3-Yb-Mpp">
+                            <rect key="frame" x="0.0" y="134" width="228" height="50"/>
                             <color key="backgroundColor" red="0.083623558282852173" green="0.66497266292572021" blue="0.84832382202148438" alpha="0.87" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="50" id="T07-nA-0QZ"/>

--- a/ios/Framework/Themes/Default/Auth/SignUpScreenlet/SignUpView_default.swift
+++ b/ios/Framework/Themes/Default/Auth/SignUpScreenlet/SignUpView_default.swift
@@ -18,17 +18,17 @@ open class SignUpView_default: BaseScreenletView, SignUpViewModel {
 
 	// MARK: Outlets
 
-	@IBOutlet open var emailAddressField: UITextField?
+	@IBOutlet open weak var emailAddressField: UITextField?
 
-	@IBOutlet open var passwordField: UITextField?
+	@IBOutlet open weak var passwordField: UITextField?
 
-	@IBOutlet open var firstNameField: UITextField?
+	@IBOutlet open weak var firstNameField: UITextField?
 
-	@IBOutlet open var lastNameField: UITextField?
+	@IBOutlet open weak var lastNameField: UITextField?
 
-	@IBOutlet open var signUpButton: UIButton?
+	@IBOutlet open weak var signUpButton: UIButton?
 
-	@IBOutlet open var scroll: UIScrollView?
+	@IBOutlet open weak var scrollView: UIScrollView?
 
 	// MARK: BaseScreenletView
 

--- a/ios/Framework/Themes/Default/Auth/SignUpScreenlet/SignUpView_default.swift
+++ b/ios/Framework/Themes/Default/Auth/SignUpScreenlet/SignUpView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(SignUpView_default)
 open class SignUpView_default: BaseScreenletView, SignUpViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/Auth/SignUpScreenlet/SignUpView_default.swift
+++ b/ios/Framework/Themes/Default/Auth/SignUpScreenlet/SignUpView_default.swift
@@ -28,7 +28,7 @@ open class SignUpView_default: BaseScreenletView, SignUpViewModel {
 
 	@IBOutlet open weak var signUpButton: UIButton?
 
-	@IBOutlet open weak var scrollView: UIScrollView?
+	@IBOutlet open weak var scroll: UIScrollView?
 
 	// MARK: BaseScreenletView
 

--- a/ios/Framework/Themes/Default/Auth/SignUpScreenlet/SignUpView_default.xib
+++ b/ios/Framework/Themes/Default/Auth/SignUpScreenlet/SignUpView_default.xib
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="SignUpView_default" customModule="LiferayScreens">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="SignUpView_default">
             <rect key="frame" x="0.0" y="0.0" width="228" height="315"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>

--- a/ios/Framework/Themes/Default/Auth/UserPortraitScreenlet/UserPortraitView_default.swift
+++ b/ios/Framework/Themes/Default/Auth/UserPortraitScreenlet/UserPortraitView_default.swift
@@ -34,6 +34,7 @@ private func loadPlaceholderCache(_ done: ((UIImage?) -> Void)? = nil) {
 	}
 }
 
+@objc(UserPortraitView_default)
 open class UserPortraitView_default: BaseScreenletView, UserPortraitViewModel,
 	UIActionSheetDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
 

--- a/ios/Framework/Themes/Default/BlogsDisplay/BlogsEntryDisplayView_default.swift
+++ b/ios/Framework/Themes/Default/BlogsDisplay/BlogsEntryDisplayView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(BlogsEntryDisplayView_default)
 open class BlogsEntryDisplayView_default: BaseScreenletView, BlogsDisplayViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/Comment/Add/CommentAddView_default.swift
+++ b/ios/Framework/Themes/Default/Comment/Add/CommentAddView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(CommentAddView_default)
 open class CommentAddView_default: BaseScreenletView, CommentAddViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/Comment/Display/CommentDisplayView_default.swift
+++ b/ios/Framework/Themes/Default/Comment/Display/CommentDisplayView_default.swift
@@ -19,6 +19,7 @@ public enum CommentDisplayState_default {
 	case editing
 }
 
+@objc(CommentDisplayView_default)
 open class CommentDisplayView_default: BaseScreenletView, CommentDisplayViewModel {
 
 	//Left/right UILabel padding

--- a/ios/Framework/Themes/Default/Comment/Display/CommentEditViewController_default.swift
+++ b/ios/Framework/Themes/Default/Comment/Display/CommentEditViewController_default.swift
@@ -15,6 +15,7 @@ import UIKit
 
 private let xibName = "CommentEditViewController_default"
 
+@objc(CommentEditViewController_default)
 open class CommentEditViewController_default: UIViewController, UITextViewDelegate {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/Comment/List/CommentListView_default.swift
+++ b/ios/Framework/Themes/Default/Comment/List/CommentListView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(CommentListView_default)
 open class CommentListView_default: BaseListTableView, CommentListViewModel {
 
 	let CommentCellId = "commentCell"

--- a/ios/Framework/Themes/Default/Comment/List/CommentTableViewCell_default.swift
+++ b/ios/Framework/Themes/Default/Comment/List/CommentTableViewCell_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(CommentTableViewCell_default)
 open class CommentTableViewCell_default: UITableViewCell {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLBaseFieldTextFieldTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLBaseFieldTextFieldTableCell_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(DDLBaseFieldTextboxTableCell_default)
 open class DDLBaseFieldTextboxTableCell_default: DDMFieldTableCell, UITextFieldDelegate {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldCheckboxTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldCheckboxTableCell_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(DDLFieldCheckboxTableCell_default)
 open class DDLFieldCheckboxTableCell_default: DDMFieldTableCell {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldDateTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldDateTableCell_default.swift
@@ -17,6 +17,7 @@ import UIKit
 	import DTPickerPresenter
 #endif
 
+@objc(DDLFieldDateTableCell_default)
 open class DDLFieldDateTableCell_default: DDLBaseFieldTextboxTableCell_default {
 
 	// MARK: UITableViewCell

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldDocumentlibraryPresenterViewController_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldDocumentlibraryPresenterViewController_default.swift
@@ -16,6 +16,7 @@ import MobileCoreServices
 
 private let xibName = "DDLFieldDocumentlibraryPresenterViewController_default"
 
+@objc(DDMFieldDocumentlibraryPresenterViewController_default)
 open class DDMFieldDocumentlibraryPresenterViewController_default: UIViewController,
 		UIImagePickerControllerDelegate, UINavigationControllerDelegate {
 

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldDocumentlibraryTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldDocumentlibraryTableCell_default.swift
@@ -18,6 +18,7 @@ import UIKit
 	import DTPickerPresenter
 #endif
 
+@objc(DDLFieldDocumentlibraryTableCell_default)
 open class DDLFieldDocumentlibraryTableCell_default: DDLBaseFieldTextboxTableCell_default {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldNumberTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldNumberTableCell_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(DDLFieldNumberTableCell_default)
 open class DDLFieldNumberTableCell_default: DDLBaseFieldTextboxTableCell_default {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldRadioTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldRadioTableCell_default.swift
@@ -17,6 +17,7 @@ import UIKit
 	import TNRadioButtonGroup
 #endif
 
+@objc(DDLFieldRadioTableCell_default)
 open class DDLFieldRadioTableCell_default: DDMFieldTableCell {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldSelectTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldSelectTableCell_default.swift
@@ -17,6 +17,7 @@ import UIKit
 	import DTPickerPresenter
 #endif
 
+@objc(DDLFieldSelectTableCell_default)
 open class DDLFieldSelectTableCell_default: DDLBaseFieldTextboxTableCell_default,
 		UITableViewDataSource, UITableViewDelegate {
 

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldTextTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldTextTableCell_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(DDLFieldTextTableCell_default)
 open class DDLFieldTextTableCell_default: DDLBaseFieldTextboxTableCell_default {
 
 	// MARK: DDLBaseFieldTextboxTableCell

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldTextareaTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFieldTextareaTableCell_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(DDLFieldTextareaTableCell_default)
 open class DDLFieldTextareaTableCell_default: DDMFieldTableCell, UITextViewDelegate {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFormView_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFormView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(DDLFormView_default)
 open class DDLFormView_default: DDLFormTableView {
 
 	override open var progressMessages: [String:ProgressMessages] {

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFormView_default.xib
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLFormView_default.xib
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="DDLFormView_default" customModule="LiferayScreens">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="DDLFormView_default">
             <rect key="frame" x="0.0" y="0.0" width="348" height="280"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
@@ -17,9 +21,9 @@
                         <constraint firstAttribute="height" constant="25" id="ygK-gQ-9fw"/>
                     </constraints>
                 </imageView>
-                <tableView clipsSubviews="YES" tag="1" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" allowsSelection="NO" showsSelectionImmediatelyOnTouchBegin="NO" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="Dwh-dT-20I">
+                <tableView clipsSubviews="YES" tag="1" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="Dwh-dT-20I">
                     <rect key="frame" x="0.0" y="0.0" width="348" height="280"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="iN0-l3-epB" id="YBy-fP-h2I"/>
                         <outlet property="delegate" destination="iN0-l3-epB" id="mEg-BQ-3CP"/>
@@ -32,7 +36,7 @@
                     </constraints>
                 </imageView>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="2E9-bF-RBx" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Nht-my-3l2"/>
                 <constraint firstItem="Dwh-dT-20I" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="RCb-wC-uM3"/>
@@ -56,7 +60,7 @@
         </view>
     </objects>
     <resources>
-        <image name="default-form-gradient-bottom.png" width="1" height="25"/>
-        <image name="default-form-gradient-top.png" width="1" height="25"/>
+        <image name="default-form-gradient-bottom.png" width="1" height="1"/>
+        <image name="default-form-gradient-top.png" width="1" height="1"/>
     </resources>
 </document>

--- a/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLSubmitButtonTableCell_default.swift
+++ b/ios/Framework/Themes/Default/DDL/FormScreenlet/DDLSubmitButtonTableCell_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(DDLSubmitButtonTableCell_default)
 open class DDLSubmitButtonTableCell_default: DDMFieldTableCell {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/DDL/ListScreenlet/DDLListView_default.swift
+++ b/ios/Framework/Themes/Default/DDL/ListScreenlet/DDLListView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(DDLListView_default)
 open class DDLListView_default: BaseListTableView, DDLListViewModel {
 
 	// MARK: DDLListViewModel

--- a/ios/Framework/Themes/Default/FileDisplay/AudioDisplayView_default.swift
+++ b/ios/Framework/Themes/Default/FileDisplay/AudioDisplayView_default.swift
@@ -14,6 +14,7 @@
 import UIKit
 import AVFoundation
 
+@objc(AudioDisplayView_default)
 open class AudioDisplayView_default: BaseScreenletView, FileDisplayViewModel {
 
 	open var volume: Float = 0.5

--- a/ios/Framework/Themes/Default/FileDisplay/FileDisplayView_default.swift
+++ b/ios/Framework/Themes/Default/FileDisplay/FileDisplayView_default.swift
@@ -13,6 +13,7 @@
 */
 import WebKit
 
+@objc(FileDisplayView_default)
 open class FileDisplayView_default: BaseScreenletView, FileDisplayViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/FileDisplay/ImageDisplayView_default.swift
+++ b/ios/Framework/Themes/Default/FileDisplay/ImageDisplayView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(ImageDisplayView_default)
 open class ImageDisplayView_default: BaseScreenletView, ImageDisplayViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/FileDisplay/PdfDisplayView_default.swift
+++ b/ios/Framework/Themes/Default/FileDisplay/PdfDisplayView_default.swift
@@ -13,6 +13,7 @@
  */
 import WebKit
 
+@objc(PdfDisplayView_default)
 open class PdfDisplayView_default: BaseScreenletView, FileDisplayViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/FileDisplay/VideoDisplayView_default.swift
+++ b/ios/Framework/Themes/Default/FileDisplay/VideoDisplayView_default.swift
@@ -15,6 +15,7 @@ import UIKit
 import AVFoundation
 import AVKit
 
+@objc(VideoDisplayView_default)
 open class VideoDisplayView_default: BaseScreenletView, FileDisplayViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/ImageGalleryScreenlet/Grid/ImageGalleryView_default.swift
+++ b/ios/Framework/Themes/Default/ImageGalleryScreenlet/Grid/ImageGalleryView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(ImageGalleryView_default)
 open class ImageGalleryView_default: ImageGalleryCollectionViewBase {
 
 	open static let DefaultColumns = 4

--- a/ios/Framework/Themes/Default/ImageGalleryScreenlet/ImageUploadDetailViewController_default.swift
+++ b/ios/Framework/Themes/Default/ImageGalleryScreenlet/ImageUploadDetailViewController_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(ImageUploadDetailViewController_default)
 open class ImageUploadDetailViewController_default: UIViewController {
 
 	open var imageUploadDetailview: ImageUploadDetailViewBase?

--- a/ios/Framework/Themes/Default/ImageGalleryScreenlet/ImageUploadDetailView_default.swift
+++ b/ios/Framework/Themes/Default/ImageGalleryScreenlet/ImageUploadDetailView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(ImageUploadDetailView_default)
 open class ImageUploadDetailView_default: ImageUploadDetailViewBase, UITextViewDelegate {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/ImageGalleryScreenlet/UploadProgressView_default.swift
+++ b/ios/Framework/Themes/Default/ImageGalleryScreenlet/UploadProgressView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(UploadProgressView_default)
 open class UploadProgressView_default: UIView, UploadProgressViewBase {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/WebContent/DisplayScreenlet/WebContentDisplayView_default.swift
+++ b/ios/Framework/Themes/Default/WebContent/DisplayScreenlet/WebContentDisplayView_default.swift
@@ -14,6 +14,7 @@
 import UIKit
 import WebKit
 
+@objc(WebContentDisplayView_default)
 open class WebContentDisplayView_default: BaseScreenletView, WebContentDisplayViewModel {
 
 	// MARK: Outlets

--- a/ios/Framework/Themes/Default/WebContent/ListScreenlet/WebContentListView_default.swift
+++ b/ios/Framework/Themes/Default/WebContent/ListScreenlet/WebContentListView_default.swift
@@ -13,6 +13,7 @@
  */
 import UIKit
 
+@objc(WebContentListView_default)
 open class WebContentListView_default: WebContentListTableView {
 
 	// MARK: BaseScreenletView


### PR DESCRIPTION
- Add name to classes annotated with @objc: It's necessary to add an understandable name to classes annotated with @objc to generate the Xamarin iOS bindings and to use understandable names in Xamarin.iOS solutions.
- Remove module name in default views.