### PR TITLE
LSR-1029 Android changes for Xamarin.Droid binding (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bugs
 * Fix error in material LoginView with cookie login
+* All screenlets should have getter and setter for their listener property
 
 ## iOS
 

--- a/android/library/src/main/java/com/liferay/mobile/screens/auth/login/LoginScreenlet.java
+++ b/android/library/src/main/java/com/liferay/mobile/screens/auth/login/LoginScreenlet.java
@@ -120,6 +120,10 @@ public class LoginScreenlet extends BaseScreenlet<LoginViewModel, BaseLoginInter
 		this.listener = listener;
 	}
 
+	public LoginListener getListener() {
+		return listener;
+	}
+
 	public BasicAuthMethod getAuthMethod() {
 		return basicAuthMethod;
 	}


### PR DESCRIPTION
- All screenlets should have getter and setter for their listener property: Xamarin binding will generate a property called `Listener` and with that we can subscribe to listener events.