### PR TITLE
#trivial MOBILE-1009 Fix crash GridField when rotated before debounce

### DIFF
--- a/android/library/src/main/java/com/liferay/mobile/screens/ddl/model/Field.java
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddl/model/Field.java
@@ -381,7 +381,7 @@ public abstract class Field<T extends Serializable> implements Parcelable {
                     }
                 }
 
-                if("document-library".equals(stringDataType)) {
+                if ("document-library".equals(stringDataType)) {
                     return DOCUMENT;
                 }
 

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/FormInstanceRecord.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/FormInstanceRecord.kt
@@ -21,6 +21,8 @@ import com.liferay.apio.consumer.model.Thing
 import com.liferay.apio.consumer.model.get
 import com.liferay.mobile.screens.ddl.form.util.FormConstants
 import com.liferay.mobile.screens.ddl.model.Field
+import org.json.JSONArray
+import org.json.JSONObject
 import java.util.*
 
 /**

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/FormInstanceRecord.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/FormInstanceRecord.kt
@@ -20,10 +20,6 @@ import android.os.Parcelable
 import com.liferay.apio.consumer.model.Thing
 import com.liferay.apio.consumer.model.get
 import com.liferay.mobile.screens.ddl.form.util.FormConstants
-import com.liferay.mobile.screens.ddl.model.Field
-import org.json.JSONArray
-import org.json.JSONObject
-import java.util.*
 
 /**
  * @author Paulo Cruz

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/GridField.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/GridField.kt
@@ -31,22 +31,22 @@ class GridField : Field<Grid>, Parcelable {
 
 	private val gson: Gson = Gson()
 
-    override fun convertToData(value: Grid?): String {
-        return value?.rawValues.let {
-            gson.toJson(it)
-        }.toString()
-    }
-
-    override fun convertToFormattedString(value: Grid?): String {
-        return value?.rawValues.let {
+	override fun convertToData(value: Grid?): String {
+		return value?.rawValues.let {
 			gson.toJson(it)
-        }.toString()
-    }
+		}.toString()
+	}
 
-    constructor(parcel: Parcel, classLoader: ClassLoader) : super(parcel, classLoader) {
-        rows = parcel.createTypedArrayList(Option.CREATOR)
-        columns = parcel.createTypedArrayList(Option.CREATOR)
-    }
+	override fun convertToFormattedString(value: Grid?): String {
+		return value?.rawValues.let {
+			gson.toJson(it)
+		}.toString()
+	}
+
+	constructor(parcel: Parcel, classLoader: ClassLoader) : super(parcel, classLoader) {
+		rows = parcel.createTypedArrayList(Option.CREATOR)
+		columns = parcel.createTypedArrayList(Option.CREATOR)
+	}
 
 	override fun writeToParcel(parcel: Parcel, flags: Int) {
 		super.writeToParcel(parcel, flags)

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/GridField.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/GridField.kt
@@ -29,15 +29,17 @@ class GridField : Field<Grid>, Parcelable {
 	var rows: List<Option>
 	var columns: List<Option>
 
+	private val gson: Gson = Gson()
+
     override fun convertToData(value: Grid?): String {
         return value?.rawValues.let {
-            Gson().toJson(it)
+            gson.toJson(it)
         }.toString()
     }
 
     override fun convertToFormattedString(value: Grid?): String {
         return value?.rawValues.let {
-            Gson().toJson(it)
+			gson.toJson(it)
         }.toString()
     }
 

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/GridField.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/GridField.kt
@@ -44,9 +44,9 @@ class GridField : Field<Grid>, Parcelable {
     }
 
     constructor(parcel: Parcel, classLoader: ClassLoader) : super(parcel, classLoader) {
-		rows = parcel.createTypedArrayList(Option.CREATOR)
-		columns = parcel.createTypedArrayList(Option.CREATOR)
-	}
+        rows = parcel.createTypedArrayList(Option.CREATOR)
+        columns = parcel.createTypedArrayList(Option.CREATOR)
+    }
 
 	override fun writeToParcel(parcel: Parcel, flags: Int) {
 		super.writeToParcel(parcel, flags)

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/GridField.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/model/GridField.kt
@@ -16,6 +16,7 @@ package com.liferay.mobile.screens.ddm.form.model
 
 import android.os.Parcel
 import android.os.Parcelable
+import com.google.gson.Gson
 import com.liferay.mobile.screens.ddl.model.Field
 import com.liferay.mobile.screens.ddl.form.util.FormFieldKeys
 import com.liferay.mobile.screens.ddl.model.Option
@@ -28,15 +29,19 @@ class GridField : Field<Grid>, Parcelable {
 	var rows: List<Option>
 	var columns: List<Option>
 
-	override fun convertToData(value: Grid?): String {
-		return value?.rawValues.toString()
-	}
+    override fun convertToData(value: Grid?): String {
+        return value?.rawValues.let {
+            Gson().toJson(it)
+        }.toString()
+    }
 
-	override fun convertToFormattedString(value: Grid?): String {
-		return value?.rawValues.toString()
-	}
+    override fun convertToFormattedString(value: Grid?): String {
+        return value?.rawValues.let {
+            Gson().toJson(it)
+        }.toString()
+    }
 
-	constructor(parcel: Parcel, classLoader: ClassLoader) : super(parcel, classLoader) {
+    constructor(parcel: Parcel, classLoader: ClassLoader) : super(parcel, classLoader) {
 		rows = parcel.createTypedArrayList(Option.CREATOR)
 		columns = parcel.createTypedArrayList(Option.CREATOR)
 	}

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormContract.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormContract.kt
@@ -74,7 +74,9 @@ interface DDMFormViewContract {
 
 		fun evaluateContext(thing: Thing, fields: MutableList<Field<*>>, onComplete: (() -> Unit)? = null)
 
-		fun onFieldValueChanged(thing: Thing, formInstance: FormInstance, field: Field<*>)
+		fun onFieldValueChanged(field: Field<*>)
+
+		fun onDebounceSync(thing: Thing, formInstance: FormInstance, field: Field<*>)
 
 		fun restore(formInstanceRecord: FormInstanceRecord?, fields: MutableList<Field<*>>)
 

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormContract.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormContract.kt
@@ -74,15 +74,15 @@ interface DDMFormViewContract {
 
 		fun evaluateContext(thing: Thing, fields: MutableList<Field<*>>, onComplete: (() -> Unit)? = null)
 
-		fun onFieldValueChanged(field: Field<*>)
+		fun fieldModelsChanged(field: Field<*>)
 
-		fun onDebounceSync(thing: Thing, formInstance: FormInstance, field: Field<*>)
+		fun syncForm(thing: Thing, formInstance: FormInstance, field: Field<*>)
 
 		fun restore(formInstanceRecord: FormInstanceRecord?, fields: MutableList<Field<*>>)
 
 		fun submit(thing: Thing, formInstance: FormInstance, isDraft: Boolean = false)
 
-		fun syncFormInstance(thing: Thing, formInstance: FormInstance)
+		fun loadInitialContext(thing: Thing, formInstance: FormInstance)
 
 		fun uploadFile(
 			thing: Thing, field: DocumentField, inputStream: InputStream, onSuccess: (DocumentRemoteFile) -> Unit,

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormPresenter.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormPresenter.kt
@@ -76,13 +76,8 @@ class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewC
 		})
 	}
 
-	override fun onFieldValueChanged(thing: Thing, formInstance: FormInstance, field: Field<*>) {
+	override fun onDebounceSync(thing: Thing, formInstance: FormInstance, field: Field<*>) {
 		if (!field.isTransient) {
-			addToDirtyFields(field)
-
-			formInstanceRecord?.let {
-				it.fieldValues[field.name] = field.toData() ?: ""
-			}
 
 			if (!view.hasConnectivity()) {
 				view.showOfflineWarningMessage()
@@ -95,6 +90,16 @@ class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewC
 				if (field.hasFormRules()) {
 					evaluateContext(thing, formInstance.ddmStructure.fields)
 				}
+			}
+		}
+	}
+
+	override fun onFieldValueChanged(field: Field<*>) {
+		if (!field.isTransient) {
+			addToDirtyFields(field)
+
+			formInstanceRecord?.let {
+				it.fieldValues[field.name] = field.toData() ?: ""
 			}
 		}
 	}

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormPresenter.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormPresenter.kt
@@ -29,7 +29,7 @@ import java.util.*
  */
 class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewContract.DDMFormViewPresenter {
 
-    private val interactor = DDMFormInteractor()
+	private val interactor = DDMFormInteractor()
 	private val dirtyFieldNames: MutableList<String> = mutableListOf()
 
 	private var isSyncing = false
@@ -86,23 +86,23 @@ class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewC
 		}
 	}
 
-    override fun syncForm(thing: Thing, formInstance: FormInstance, field: Field<*>) {
-        if (!field.isTransient) {
+	override fun syncForm(thing: Thing, formInstance: FormInstance, field: Field<*>) {
+		if (!field.isTransient) {
 
-            if (!view.hasConnectivity()) {
-                view.showOfflineWarningMessage()
-                return
-            }
+			if (!view.hasConnectivity()) {
+				view.showOfflineWarningMessage()
+				return
+			}
 
-            if (!isSyncing) {
-                submit(thing, formInstance, true)
+			if (!isSyncing) {
+				submit(thing, formInstance, true)
 
-                if (field.hasFormRules()) {
-                    evaluateContext(thing, formInstance.ddmStructure.fields)
-                }
-            }
-        }
-    }
+				if (field.hasFormRules()) {
+					evaluateContext(thing, formInstance.ddmStructure.fields)
+				}
+			}
+		}
+	}
 
 	override fun restore(formInstanceRecord: FormInstanceRecord?, fields: MutableList<Field<*>>) {
 		formInstanceRecord?.let {

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormPresenter.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormPresenter.kt
@@ -76,7 +76,7 @@ class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewC
 		})
 	}
 
-	override fun onFieldValueChanged(field: Field<*>) {
+	override fun fieldModelsChanged(field: Field<*>) {
 		if (!field.isTransient) {
 			addToDirtyFields(field)
 
@@ -86,7 +86,7 @@ class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewC
 		}
 	}
 
-    override fun onDebounceSync(thing: Thing, formInstance: FormInstance, field: Field<*>) {
+    override fun syncForm(thing: Thing, formInstance: FormInstance, field: Field<*>) {
         if (!field.isTransient) {
 
             if (!view.hasConnectivity()) {
@@ -138,7 +138,7 @@ class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewC
 		})
 	}
 
-	override fun syncFormInstance(thing: Thing, formInstance: FormInstance) {
+	override fun loadInitialContext(thing: Thing, formInstance: FormInstance) {
 		isSyncing = true
 		view.showModalSyncFormLoading()
 

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormPresenter.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormPresenter.kt
@@ -29,7 +29,7 @@ import java.util.*
  */
 class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewContract.DDMFormViewPresenter {
 
-	private val interactor = DDMFormInteractor()
+    private val interactor = DDMFormInteractor()
 	private val dirtyFieldNames: MutableList<String> = mutableListOf()
 
 	private var isSyncing = false
@@ -76,24 +76,6 @@ class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewC
 		})
 	}
 
-	override fun onDebounceSync(thing: Thing, formInstance: FormInstance, field: Field<*>) {
-		if (!field.isTransient) {
-
-			if (!view.hasConnectivity()) {
-				view.showOfflineWarningMessage()
-				return
-			}
-
-			if (!isSyncing) {
-				submit(thing, formInstance, true)
-
-				if (field.hasFormRules()) {
-					evaluateContext(thing, formInstance.ddmStructure.fields)
-				}
-			}
-		}
-	}
-
 	override fun onFieldValueChanged(field: Field<*>) {
 		if (!field.isTransient) {
 			addToDirtyFields(field)
@@ -103,6 +85,24 @@ class DDMFormPresenter(val view: DDMFormViewContract.DDMFormView) : DDMFormViewC
 			}
 		}
 	}
+
+    override fun onDebounceSync(thing: Thing, formInstance: FormInstance, field: Field<*>) {
+        if (!field.isTransient) {
+
+            if (!view.hasConnectivity()) {
+                view.showOfflineWarningMessage()
+                return
+            }
+
+            if (!isSyncing) {
+                submit(thing, formInstance, true)
+
+                if (field.hasFormRules()) {
+                    evaluateContext(thing, formInstance.ddmStructure.fields)
+                }
+            }
+        }
+    }
 
 	override fun restore(formInstanceRecord: FormInstanceRecord?, fields: MutableList<Field<*>>) {
 		formInstanceRecord?.let {

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
@@ -246,10 +246,9 @@ class DDMFormView @JvmOverloads constructor(
 		}
 	}
 
-    override fun subscribeToValueChanged(observable: Observable<Field<*>>) {
-        val autoSaveSubscription = observable.doOnNext {
+	override fun subscribeToValueChanged(observable: Observable<Field<*>>) {
+        subscription = observable.doOnNext {
             presenter.onFieldValueChanged(it)
-
         }.debounce(2, TimeUnit.SECONDS)
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({ field ->
@@ -259,9 +258,7 @@ class DDMFormView @JvmOverloads constructor(
             }, {
                 LiferayLogger.e(it.message)
             })
-
-        subscription = autoSaveSubscription
-    }
+	}
 
 	override fun updateFieldView(fieldContext: FieldContext, field: Field<*>) {
 		val fieldsContainerView = ddmFieldViewPages.currentView

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
@@ -246,19 +246,19 @@ class DDMFormView @JvmOverloads constructor(
 		}
 	}
 
-    override fun subscribeToValueChanged(observable: Observable<Field<*>>) {
-        subscription = observable.doOnNext {
-            presenter.fieldModelsChanged(it)
-        }.debounce(2, TimeUnit.SECONDS)
-        .observeOn(AndroidSchedulers.mainThread())
-        .subscribe({ field ->
-            thing?.let {
-                presenter.syncForm(it, formInstance, field)
-            } ?: throw Exception("No thing found")
-        }, {
-            LiferayLogger.e(it.message)
-        })
-    }
+	override fun subscribeToValueChanged(observable: Observable<Field<*>>) {
+		subscription = observable.doOnNext {
+			presenter.fieldModelsChanged(it)
+		}.debounce(2, TimeUnit.SECONDS)
+			.observeOn(AndroidSchedulers.mainThread())
+			.subscribe({ field ->
+				thing?.let {
+					presenter.syncForm(it, formInstance, field)
+				} ?: throw Exception("No thing found")
+			}, {
+				LiferayLogger.e(it.message)
+			})
+	}
 
 	override fun updateFieldView(fieldContext: FieldContext, field: Field<*>) {
 		val fieldsContainerView = ddmFieldViewPages.currentView

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
@@ -246,19 +246,19 @@ class DDMFormView @JvmOverloads constructor(
 		}
 	}
 
-	override fun subscribeToValueChanged(observable: Observable<Field<*>>) {
+    override fun subscribeToValueChanged(observable: Observable<Field<*>>) {
         subscription = observable.doOnNext {
-            presenter.onFieldValueChanged(it)
+            presenter.fieldModelsChanged(it)
         }.debounce(2, TimeUnit.SECONDS)
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe({ field ->
-                thing?.let {
-                    presenter.onDebounceSync(it, formInstance, field)
-                }
-            }, {
-                LiferayLogger.e(it.message)
-            })
-	}
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe({ field ->
+            thing?.let {
+                presenter.syncForm(it, formInstance, field)
+            } ?: throw Exception("No thing found")
+        }, {
+            LiferayLogger.e(it.message)
+        })
+    }
 
 	override fun updateFieldView(fieldContext: FieldContext, field: Field<*>) {
 		val fieldsContainerView = ddmFieldViewPages.currentView
@@ -422,7 +422,7 @@ class DDMFormView @JvmOverloads constructor(
 		setActivityTitle(formInstance)
 		initPageAdapter(formInstance.ddmStructure.pages)
 
-		presenter.syncFormInstance(thing, formInstance)
+		presenter.loadInitialContext(thing, formInstance)
 	}
 
 	private fun restoreActionButtonsState() {

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
@@ -78,7 +78,7 @@ class DDMFormView @JvmOverloads constructor(
 	private val multipageProgress by bindNonNull<ProgressBar>(R.id.liferay_multipage_progress)
 	private val modalProgress by bindNonNull<ModalProgressBarWithLabel>(R.id.liferay_modal_progress)
 
-	private var subscription: CompositeSubscription = CompositeSubscription()
+	private lateinit var subscription: Subscription
 
 	private lateinit var formInstance: FormInstance
 
@@ -246,15 +246,22 @@ class DDMFormView @JvmOverloads constructor(
 		}
 	}
 
-	override fun subscribeToValueChanged(observable: Observable<Field<*>>) {
-		val autoSaveSubscription = observable.subscribeOnChange(2) { field ->
-			thing?.let {
-				presenter.onFieldValueChanged(it, formInstance, field)
-			}
-		}
+    override fun subscribeToValueChanged(observable: Observable<Field<*>>) {
+        val autoSaveSubscription = observable.doOnNext {
+            presenter.onFieldValueChanged(it)
 
-		subscription.add(autoSaveSubscription)
-	}
+        }.debounce(2, TimeUnit.SECONDS)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe({ field ->
+                thing?.let {
+                    presenter.onDebounceSync(it, formInstance, field)
+                }
+            }, {
+                LiferayLogger.e(it.message)
+            })
+
+        subscription = autoSaveSubscription
+    }
 
 	override fun updateFieldView(fieldContext: FieldContext, field: Field<*>) {
 		val fieldsContainerView = ddmFieldViewPages.currentView
@@ -410,17 +417,6 @@ class DDMFormView @JvmOverloads constructor(
 				highLightInvalidFields(invalidFields, true)
 			}
 		}
-	}
-
-	private fun Observable<Field<*>>.subscribeOnChange(
-		debounceTimeout: Long, onNext: (Field<*>) -> Unit): Subscription {
-
-		return this
-			.debounce(debounceTimeout, TimeUnit.SECONDS)
-			.observeOn(AndroidSchedulers.mainThread())
-			.subscribe(onNext) {
-				LiferayLogger.e(it.message)
-			}
 	}
 
 	private fun onFormLoaded(formInstance: FormInstance) {


### PR DESCRIPTION
@victorg1991 @dgarciasarai 
Fix was made on GridField to parse string map format to json format avoiding crash when data value is restored to field.