### PR TITLE
MOBILE-1048 Create DDMFormsScreenlet wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ All notable changes to this project will be documented in this file.
 ### New Features
 
 * Create ThingScreenlet
-* FormsScreenlet - Allow developers to handle with value changes for all fields using onChangeValueObservable
-* FormsScreenlet - Show only FileName instead of the full path on DocumentField
+* DDMFormScreenlet - Allow developers to handle with value changes for all fields using onChangeValueObservable
+* DDMFormScreenlet - Show only FileName instead of the full path on DocumentField
 * Create a ModalProgressBar view
 * Configure `detekt` for code convention and format all the project
 * Update ThingScreenlet with ApioConsumer 0.0.8 changes
@@ -22,12 +22,13 @@ All notable changes to this project will be documented in this file.
 * Support onPageRendered method on PdfDisplayView
 * Support forms with ThingScreenlet
 * Add Lexicon Theme for Form fields
+* Add DDMFormScreenlet as a Wrapper for ThingScreenlet that handles form instances
 
 ### Refactor
 
-* FormsScreenlet - Create an abstract OptionsField type as a base class of fields that select options
+* DDMFormScreenlet - Create an abstract OptionsField type as a base class of fields that select options
 * Create a ThemeUtil class to help with custom themes
-* FormsScreenlet changes to adapt to API
+* DDMFormScreenlet changes to adapt to API
 
 ### Bugs
 
@@ -79,8 +80,8 @@ Swift 4.2 support
 
 * Add a new method to the sync service to know if there are items to synchronize
 * Add Lexicon Theme
-* FormsScreenlet - Add support to upload images and videos from gallery
-* FormsScreenlet - Required fields are now marked with an asterisk (*)
+* DDMFormScreenlet - Add support to upload images and videos from gallery
+* DDMFormScreenlet - Required fields are now marked with an asterisk (*)
 * WebScreenlet now correctly inject the script when navigate to another page
 
 ### Samples

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormListener.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormListener.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.mobile.screens.ddm.form
+
+import com.liferay.mobile.screens.ddm.form.model.FormInstance
+import java.lang.Exception
+
+/**
+ * @author Marcelo Mello
+ */
+interface DDMFormListener {
+
+    fun onFormLoaded(formInstance: FormInstance);
+
+    fun onError(exception: Exception);
+
+}

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormListener.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormListener.kt
@@ -22,8 +22,8 @@ import java.lang.Exception
  */
 interface DDMFormListener {
 
-    fun onFormLoaded(formInstance: FormInstance);
+	fun onFormLoaded(formInstance: FormInstance);
 
-    fun onError(exception: Exception);
+	fun onError(exception: Exception);
 
 }

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or modify it under
@@ -34,59 +34,37 @@ import com.liferay.mobile.screens.viewsets.defaultviews.ddm.form.DDMFormView
 class DDMFormScreenlet @JvmOverloads constructor(
 	context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : FrameLayout(context, attrs, defStyleAttr) {
 
-	var formInstanceId: Long
+	var formInstanceId: Long?
 	var listener: DDMFormListener? = null
 	val screenlet: ThingScreenlet
 
 	init {
 		val typedArray: TypedArray =
-			context.getTheme().obtainStyledAttributes(attrs, R.styleable.DDMFormScreenlet, 0, 0)
+			context.theme.obtainStyledAttributes(attrs, R.styleable.DDMFormScreenlet, defStyleAttr, 0)
 
-		formInstanceId =
-			castToLong(typedArray.getString(R.styleable.DDMFormScreenlet_formInstanceId))
-
+		formInstanceId = typedArray.getString(R.styleable.DDMFormScreenlet_formInstanceId)?.toLongOrNull()
 		typedArray.recycle()
 
 		screenlet = ThingScreenlet(context, attrs, defStyleAttr)
 		addView(screenlet)
 	}
 
-	fun load() {
-		val url: String = getResourcePath()
-		screenlet.load(url, Detail, onSuccess = {
-			(it.baseView as? DDMFormView)?.let { ddmFormView ->
-				listener?.onFormLoaded(ddmFormView.formInstance)
-			}
-		}, onError = {
-			listener?.onError(it)
-		})
-	}
+	@JvmOverloads fun load(formInstanceId: Long? = this.formInstanceId) {
+		formInstanceId?.also {
+			val url: String = getResourcePath(it)
 
-//    protected fun onRestoreInstanceState(state: Parcelable)
-
-	/**
-	 * TODO: Methods below are copied from BaseScreenlet.java class.
-	 * Need to think another approach for these methods
-	 */
-	protected fun castToLong(value: String?): Long {
-		return castToLongOrUseDefault(value, 0)
-	}
-
-	protected fun castToLongOrUseDefault(value: String?, defaultValue: Long): Long {
-		if (value == null) {
-			return defaultValue
-		}
-
-		try {
-			return java.lang.Long.parseLong(value)
-		} catch (e: NumberFormatException) {
-			LiferayLogger.e("You have supplied a string and we expected a long number", e)
-			throw e
+			screenlet.load(url, Detail, onSuccess = { thingScreenlet ->
+				(thingScreenlet.baseView as? DDMFormView)?.let { ddmFormView ->
+					listener?.onFormLoaded(ddmFormView.formInstance)
+				}
+			}, onError = {
+				listener?.onError(it)
+			})
 		}
 	}
 
-	private fun getResourcePath(): String {
-		val serverUrl = getResources().getString(R.string.liferay_server)
+	private fun getResourcePath(formInstanceId: Long): String {
+		val serverUrl = resources.getString(R.string.liferay_server)
 		return serverUrl + String.format(FormConstants.URL_TEMPLATE, formInstanceId)
 	}
 }

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
@@ -32,61 +32,61 @@ import com.liferay.mobile.screens.viewsets.defaultviews.ddm.form.DDMFormView
  * @author Marcelo Mello
  */
 class DDMFormScreenlet @JvmOverloads constructor(
-    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : FrameLayout(context, attrs, defStyleAttr) {
+	context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : FrameLayout(context, attrs, defStyleAttr) {
 
-    var formInstanceId: Long
-    var listener: DDMFormListener? = null
-    val screenlet: ThingScreenlet
+	var formInstanceId: Long
+	var listener: DDMFormListener? = null
+	val screenlet: ThingScreenlet
 
-    init {
-        val typedArray: TypedArray =
-            context.getTheme().obtainStyledAttributes(attrs, R.styleable.DDMFormScreenlet, 0, 0)
+	init {
+		val typedArray: TypedArray =
+			context.getTheme().obtainStyledAttributes(attrs, R.styleable.DDMFormScreenlet, 0, 0)
 
-        formInstanceId =
-            castToLong(typedArray.getString(R.styleable.DDMFormScreenlet_formInstanceId))
+		formInstanceId =
+			castToLong(typedArray.getString(R.styleable.DDMFormScreenlet_formInstanceId))
 
-        typedArray.recycle()
+		typedArray.recycle()
 
-        screenlet = ThingScreenlet(context, attrs, defStyleAttr)
-        addView(screenlet)
-    }
+		screenlet = ThingScreenlet(context, attrs, defStyleAttr)
+		addView(screenlet)
+	}
 
-    fun load() {
-        val url: String = getResourcePath()
-        screenlet.load(url, Detail, onSuccess = {
-            (it.baseView as? DDMFormView)?.let { ddmFormView ->
-                listener?.onFormLoaded(ddmFormView.formInstance)
-            }
-        }, onError = {
-            listener?.onError(it)
-        })
-    }
+	fun load() {
+		val url: String = getResourcePath()
+		screenlet.load(url, Detail, onSuccess = {
+			(it.baseView as? DDMFormView)?.let { ddmFormView ->
+				listener?.onFormLoaded(ddmFormView.formInstance)
+			}
+		}, onError = {
+			listener?.onError(it)
+		})
+	}
 
 //    protected fun onRestoreInstanceState(state: Parcelable)
 
-    /**
-     * TODO: Methods below are copied from BaseScreenlet.java class.
-     * Need to think another approach for these methods
-     */
-    protected fun castToLong(value: String?): Long {
-        return castToLongOrUseDefault(value, 0)
-    }
+	/**
+	 * TODO: Methods below are copied from BaseScreenlet.java class.
+	 * Need to think another approach for these methods
+	 */
+	protected fun castToLong(value: String?): Long {
+		return castToLongOrUseDefault(value, 0)
+	}
 
-    protected fun castToLongOrUseDefault(value: String?, defaultValue: Long): Long {
-        if (value == null) {
-            return defaultValue
-        }
+	protected fun castToLongOrUseDefault(value: String?, defaultValue: Long): Long {
+		if (value == null) {
+			return defaultValue
+		}
 
-        try {
-            return java.lang.Long.parseLong(value)
-        } catch (e: NumberFormatException) {
-            LiferayLogger.e("You have supplied a string and we expected a long number", e)
-            throw e
-        }
-    }
+		try {
+			return java.lang.Long.parseLong(value)
+		} catch (e: NumberFormatException) {
+			LiferayLogger.e("You have supplied a string and we expected a long number", e)
+			throw e
+		}
+	}
 
-    private fun getResourcePath(): String {
-        val serverUrl = getResources().getString(R.string.liferay_server)
-        return serverUrl + String.format(FormConstants.URL_TEMPLATE, formInstanceId)
-    }
+	private fun getResourcePath(): String {
+		val serverUrl = getResources().getString(R.string.liferay_server)
+		return serverUrl + String.format(FormConstants.URL_TEMPLATE, formInstanceId)
+	}
 }

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.mobile.screens.ddm.form
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import com.liferay.mobile.screens.R
+import com.liferay.mobile.screens.ddl.form.util.FormConstants
+import com.liferay.mobile.screens.thingscreenlet.screens.ThingScreenlet
+import com.liferay.mobile.screens.thingscreenlet.screens.views.Detail
+import com.liferay.mobile.screens.util.LiferayLogger
+import com.liferay.mobile.screens.viewsets.defaultviews.ddm.form.DDMFormView
+
+/**
+ * @author Marcelo Mello
+ */
+class DDMFormScreenlet @JvmOverloads constructor(
+        context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : FrameLayout(context, attrs, defStyleAttr) {
+
+    var formInstanceId: Long
+    var listener: DDMFormListener? = null
+    val screenlet: ThingScreenlet
+
+    init {
+        val typedArray: TypedArray =
+                context.getTheme().obtainStyledAttributes(attrs, R.styleable.DDMFormScreenlet, 0, 0)
+
+        formInstanceId =
+                castToLong(typedArray.getString(R.styleable.DDMFormScreenlet_formInstanceId))
+
+        typedArray.recycle()
+
+        screenlet = ThingScreenlet(context, attrs, defStyleAttr)
+        addView(screenlet)
+    }
+
+    fun load() {
+        val url: String = getResourcePath()
+
+        screenlet.load(url, Detail, onSuccess = {
+            (it.baseView as? DDMFormView)?.let { ddmFormView ->
+                listener?.onFormLoaded(ddmFormView.formInstance)
+            }
+        }, onError = {
+            listener?.onError(it)
+        })
+    }
+
+    private fun getResourcePath(): String {
+        val serverUrl = getResources().getString(R.string.liferay_server)
+        return serverUrl + String.format(FormConstants.URL_TEMPLATE, formInstanceId)
+    }
+
+    /**
+     * TODO: Methods below are copied from BaseScreenlet.java class.
+     * Need to think another approach for these methods
+     */
+    protected fun castToLong(value: String?): Long {
+        return castToLongOrUseDefault(value, 0)
+    }
+
+    protected fun castToLongOrUseDefault(value: String?, defaultValue: Long): Long {
+        if (value == null) {
+            return defaultValue
+        }
+        try {
+            return java.lang.Long.parseLong(value)
+        } catch (e: NumberFormatException) {
+            LiferayLogger.e("You have supplied a string and we expected a long number", e)
+            throw e
+        }
+
+    }
+
+}

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
@@ -53,7 +53,6 @@ class DDMFormScreenlet @JvmOverloads constructor(
 
     fun load() {
         val url: String = getResourcePath()
-
         screenlet.load(url, Detail, onSuccess = {
             (it.baseView as? DDMFormView)?.let { ddmFormView ->
                 listener?.onFormLoaded(ddmFormView.formInstance)
@@ -63,10 +62,7 @@ class DDMFormScreenlet @JvmOverloads constructor(
         })
     }
 
-    private fun getResourcePath(): String {
-        val serverUrl = getResources().getString(R.string.liferay_server)
-        return serverUrl + String.format(FormConstants.URL_TEMPLATE, formInstanceId)
-    }
+//    protected fun onRestoreInstanceState(state: Parcelable)
 
     /**
      * TODO: Methods below are copied from BaseScreenlet.java class.
@@ -89,4 +85,8 @@ class DDMFormScreenlet @JvmOverloads constructor(
         }
     }
 
+    private fun getResourcePath(): String {
+        val serverUrl = getResources().getString(R.string.liferay_server)
+        return serverUrl + String.format(FormConstants.URL_TEMPLATE, formInstanceId)
+    }
 }

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
@@ -16,7 +16,10 @@ package com.liferay.mobile.screens.ddm.form
 
 import android.content.Context
 import android.content.res.TypedArray
+import android.os.Bundle
+import android.os.Parcelable
 import android.util.AttributeSet
+import android.view.View
 import android.widget.FrameLayout
 import com.liferay.mobile.screens.R
 import com.liferay.mobile.screens.ddl.form.util.FormConstants
@@ -29,7 +32,7 @@ import com.liferay.mobile.screens.viewsets.defaultviews.ddm.form.DDMFormView
  * @author Marcelo Mello
  */
 class DDMFormScreenlet @JvmOverloads constructor(
-        context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : FrameLayout(context, attrs, defStyleAttr) {
+    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : FrameLayout(context, attrs, defStyleAttr) {
 
     var formInstanceId: Long
     var listener: DDMFormListener? = null
@@ -37,10 +40,10 @@ class DDMFormScreenlet @JvmOverloads constructor(
 
     init {
         val typedArray: TypedArray =
-                context.getTheme().obtainStyledAttributes(attrs, R.styleable.DDMFormScreenlet, 0, 0)
+            context.getTheme().obtainStyledAttributes(attrs, R.styleable.DDMFormScreenlet, 0, 0)
 
         formInstanceId =
-                castToLong(typedArray.getString(R.styleable.DDMFormScreenlet_formInstanceId))
+            castToLong(typedArray.getString(R.styleable.DDMFormScreenlet_formInstanceId))
 
         typedArray.recycle()
 
@@ -77,13 +80,13 @@ class DDMFormScreenlet @JvmOverloads constructor(
         if (value == null) {
             return defaultValue
         }
+
         try {
             return java.lang.Long.parseLong(value)
         } catch (e: NumberFormatException) {
             LiferayLogger.e("You have supplied a string and we expected a long number", e)
             throw e
         }
-
     }
 
 }

--- a/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/ddm/form/DDMFormScreenlet.kt
@@ -49,7 +49,8 @@ class DDMFormScreenlet @JvmOverloads constructor(
 		addView(screenlet)
 	}
 
-	@JvmOverloads fun load(formInstanceId: Long? = this.formInstanceId) {
+	@JvmOverloads
+	fun load(formInstanceId: Long? = this.formInstanceId) {
 		formInstanceId?.also {
 			val url: String = getResourcePath(it)
 

--- a/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
@@ -16,6 +16,7 @@ package com.liferay.mobile.screens.thingscreenlet.screens
 
 import android.content.Context
 import android.os.Bundle
+import android.os.Parcel
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.View
@@ -38,10 +39,10 @@ import com.liferay.mobile.screens.thingscreenlet.screens.views.*
 import okhttp3.HttpUrl
 
 open class BaseScreenlet @JvmOverloads constructor(
-	context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0, defStyleRes: Int = 0) :
-	FrameLayout(context, attrs, defStyleAttr) {
+    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0, defStyleRes: Int = 0) :
+    FrameLayout(context, attrs, defStyleAttr) {
 
-	var layout: View? = null
+    var layout: View? = null
 }
 
 open class ThingScreenlet @JvmOverloads constructor(
@@ -163,32 +164,9 @@ open class ThingScreenlet @JvmOverloads constructor(
 	}
 
 	override fun onFinishInflate() {
-		super.onFinishInflate()
-		isSaveEnabled = true
-	}
-
-	override fun onSaveInstanceState(): Parcelable {
-		thing?.let {
-			val bundle = Bundle()
-			bundle.putParcelable("superState", super.onSaveInstanceState())
-			bundle.putParcelable("thing", it)
-			bundle.putParcelable("scenario", scenario)
-			return bundle
-		}
-
-		return super.onSaveInstanceState()
-	}
-
-	override fun onRestoreInstanceState(state: Parcelable?) {
-		if (state is Bundle) {
-			savedInstanceState = state
-			scenario = state.getParcelable("scenario")
-			thing = state.getParcelable("thing")
-			super.onRestoreInstanceState(state.getParcelable("superState"))
-		} else {
-			super.onRestoreInstanceState(state)
-		}
-	}
+        super.onFinishInflate()
+        isSaveEnabled = true
+    }
 
 	private fun getApioAuthenticator(credentials: String? = null): ApioAuthenticator? {
 		val credentials = credentials ?: SessionContext.getCredentialsFromCurrentSession()
@@ -198,4 +176,23 @@ open class ThingScreenlet @JvmOverloads constructor(
 		}
 	}
 
+    override fun onSaveInstanceState(): Parcelable {
+        var savedState = ThingScreenletSavedState(super.onSaveInstanceState())
+
+		savedState.scenario = scenario
+        thing?.let {
+            savedState.thing = it
+        }
+
+        return savedState
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        var savedState: ThingScreenletSavedState = state as ThingScreenletSavedState
+		scenario = savedState.scenario
+        thing = savedState.thing
+        super.onRestoreInstanceState(state)
+    }
 }
+
+

--- a/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
@@ -180,19 +180,19 @@ open class ThingScreenlet @JvmOverloads constructor(
 		var savedState = ThingScreenletSavedState(super.onSaveInstanceState())
 
 		savedState.scenario = scenario
-        thing?.let {
-            savedState.thing = it
-        }
+		thing?.let {
+			savedState.thing = it
+		}
 
 		return savedState
 	}
 
-    override fun onRestoreInstanceState(state: Parcelable?) {
-        var savedState = state as ThingScreenletSavedState
+	override fun onRestoreInstanceState(state: Parcelable?) {
+		var savedState = state as ThingScreenletSavedState
 		scenario = savedState.scenario
-        thing = savedState.thing
-        super.onRestoreInstanceState(state)
-    }
+		thing = savedState.thing
+		super.onRestoreInstanceState(state)
+	}
 }
 
 

--- a/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
@@ -188,7 +188,7 @@ open class ThingScreenlet @JvmOverloads constructor(
 	}
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        var savedState: ThingScreenletSavedState = state as ThingScreenletSavedState
+        var savedState = state as ThingScreenletSavedState
 		scenario = savedState.scenario
         thing = savedState.thing
         super.onRestoreInstanceState(state)

--- a/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
@@ -51,6 +51,7 @@ open class ThingScreenlet @JvmOverloads constructor(
 	open var scenario: Scenario = Detail
 
 	var screenletEvents: ScreenletEvents? = null
+	var savedInstanceState: Bundle? = null
 
 	open var layoutIds: MutableMap<String, MutableMap<Scenario, Int>> = mutableMapOf(
 		"BlogPosting" to BlogPosting.DEFAULT_VIEWS,
@@ -84,6 +85,7 @@ open class ThingScreenlet @JvmOverloads constructor(
 		} else {
 			baseView?.thing = it
 		}
+		savedInstanceState = null
 	}
 
 	val baseView: BaseView? get() = layout as? BaseView
@@ -179,6 +181,7 @@ open class ThingScreenlet @JvmOverloads constructor(
 
 	override fun onRestoreInstanceState(state: Parcelable?) {
 		if (state is Bundle) {
+			savedInstanceState = state
 			scenario = state.getParcelable("scenario")
 			thing = state.getParcelable("thing")
 			super.onRestoreInstanceState(state.getParcelable("superState"))

--- a/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenlet.kt
@@ -39,10 +39,10 @@ import com.liferay.mobile.screens.thingscreenlet.screens.views.*
 import okhttp3.HttpUrl
 
 open class BaseScreenlet @JvmOverloads constructor(
-    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0, defStyleRes: Int = 0) :
-    FrameLayout(context, attrs, defStyleAttr) {
+	context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0, defStyleRes: Int = 0) :
+	FrameLayout(context, attrs, defStyleAttr) {
 
-    var layout: View? = null
+	var layout: View? = null
 }
 
 open class ThingScreenlet @JvmOverloads constructor(
@@ -164,9 +164,9 @@ open class ThingScreenlet @JvmOverloads constructor(
 	}
 
 	override fun onFinishInflate() {
-        super.onFinishInflate()
-        isSaveEnabled = true
-    }
+		super.onFinishInflate()
+		isSaveEnabled = true
+	}
 
 	private fun getApioAuthenticator(credentials: String? = null): ApioAuthenticator? {
 		val credentials = credentials ?: SessionContext.getCredentialsFromCurrentSession()
@@ -176,16 +176,16 @@ open class ThingScreenlet @JvmOverloads constructor(
 		}
 	}
 
-    override fun onSaveInstanceState(): Parcelable {
-        var savedState = ThingScreenletSavedState(super.onSaveInstanceState())
+	override fun onSaveInstanceState(): Parcelable {
+		var savedState = ThingScreenletSavedState(super.onSaveInstanceState())
 
 		savedState.scenario = scenario
         thing?.let {
             savedState.thing = it
         }
 
-        return savedState
-    }
+		return savedState
+	}
 
     override fun onRestoreInstanceState(state: Parcelable?) {
         var savedState: ThingScreenletSavedState = state as ThingScreenletSavedState

--- a/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenletSavedState.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenletSavedState.kt
@@ -25,8 +25,8 @@ import com.liferay.mobile.screens.thingscreenlet.screens.views.Scenario
  */
 class ThingScreenletSavedState : View.BaseSavedState {
 
-    lateinit var thing: Thing
-    lateinit var scenario: Scenario
+	lateinit var thing: Thing
+	lateinit var scenario: Scenario
 
 	constructor(superState: Parcelable) : super(superState)
 

--- a/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenletSavedState.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenletSavedState.kt
@@ -28,28 +28,26 @@ class ThingScreenletSavedState : View.BaseSavedState {
     lateinit var thing: Thing
     lateinit var scenario: Scenario
 
-    constructor(superState: Parcelable) : super(superState)
+	constructor(superState: Parcelable) : super(superState)
 
-    internal constructor(parcel: Parcel) : super(parcel) {
-        thing = parcel.readParcelable(Thing::class.java.classLoader)
-        thing = parcel.readParcelable(Scenario::class.java.classLoader)
-    }
+	internal constructor(parcel: Parcel) : super(parcel) {
+		thing = parcel.readParcelable(Thing::class.java.classLoader)
+	}
 
-    override fun writeToParcel(out: Parcel, flags: Int) {
-        super.writeToParcel(out, flags)
-        out.writeParcelable(thing, flags)
-        out.writeParcelable(scenario, flags)
-    }
+	override fun writeToParcel(out: Parcel, flags: Int) {
+		super.writeToParcel(out, flags)
+		out.writeParcelable(thing, flags)
+	}
 
-    object CREATOR : Parcelable.Creator<ThingScreenletSavedState> {
-        override fun createFromParcel(parcel: Parcel): ThingScreenletSavedState {
-            return ThingScreenletSavedState(parcel)
-        }
+	object CREATOR : Parcelable.Creator<ThingScreenletSavedState> {
+		override fun createFromParcel(parcel: Parcel): ThingScreenletSavedState {
+			return ThingScreenletSavedState(parcel)
+		}
 
-        override fun newArray(size: Int): Array<ThingScreenletSavedState?> {
-            return arrayOfNulls(size)
-        }
-    }
+		override fun newArray(size: Int): Array<ThingScreenletSavedState?> {
+			return arrayOfNulls(size)
+		}
+	}
 
-    override fun describeContents(): Int = 0
+	override fun describeContents(): Int = 0
 }

--- a/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenletSavedState.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/thingscreenlet/screens/ThingScreenletSavedState.kt
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.mobile.screens.thingscreenlet.screens
+
+import android.os.Parcel
+import android.os.Parcelable
+import android.view.View
+import com.liferay.apio.consumer.model.Thing
+import com.liferay.mobile.screens.thingscreenlet.screens.views.Scenario
+
+/**
+ * @author Marcelo Mello
+ */
+class ThingScreenletSavedState : View.BaseSavedState {
+
+    lateinit var thing: Thing
+    lateinit var scenario: Scenario
+
+    constructor(superState: Parcelable) : super(superState)
+
+    internal constructor(parcel: Parcel) : super(parcel) {
+        thing = parcel.readParcelable(Thing::class.java.classLoader)
+        thing = parcel.readParcelable(Scenario::class.java.classLoader)
+    }
+
+    override fun writeToParcel(out: Parcel, flags: Int) {
+        super.writeToParcel(out, flags)
+        out.writeParcelable(thing, flags)
+        out.writeParcelable(scenario, flags)
+    }
+
+    object CREATOR : Parcelable.Creator<ThingScreenletSavedState> {
+        override fun createFromParcel(parcel: Parcel): ThingScreenletSavedState {
+            return ThingScreenletSavedState(parcel)
+        }
+
+        override fun newArray(size: Int): Array<ThingScreenletSavedState?> {
+            return arrayOfNulls(size)
+        }
+    }
+
+    override fun describeContents(): Int = 0
+}

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
@@ -86,7 +86,10 @@ class DDMFormView @JvmOverloads constructor(
 
 	override var thing: Thing? by converter<FormInstance> {
 		formInstance = it
-		onFormLoaded(formInstance)
+
+		if (screenlet?.savedInstanceState == null) {
+			onFormLoaded(formInstance)
+		}
 	}
 
 	init {
@@ -145,6 +148,10 @@ class DDMFormView @JvmOverloads constructor(
 
 	override fun onRestoreInstanceState(state: Parcelable?) {
 		if (state is Bundle) {
+			screenlet?.thing?.also {
+				thing = it
+			}
+
 			val formInstanceRecord = state.getParcelable<FormInstanceRecord>("formInstanceRecord")
 			presenter.restore(formInstanceRecord, formInstance.ddmStructure.fields)
 

--- a/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
+++ b/android/library/src/main/java/com/liferay/mobile/screens/viewsets/defaultviews/ddm/form/DDMFormView.kt
@@ -80,7 +80,7 @@ class DDMFormView @JvmOverloads constructor(
 
 	private lateinit var subscription: Subscription
 
-	private lateinit var formInstance: FormInstance
+	internal lateinit var formInstance: FormInstance
 
 	override var screenlet: ThingScreenlet? = null
 

--- a/android/library/src/main/res/values/attrs.xml
+++ b/android/library/src/main/res/values/attrs.xml
@@ -148,6 +148,10 @@
         <attr name="obcClassName"/>
     </declare-styleable>
 
+	<declare-styleable name="DDMFormScreenlet">
+		<attr name="formInstanceId"/>
+	</declare-styleable>
+
     <declare-styleable name="ForgotPasswordScreenlet">
         <attr name="layoutId"/>
         <attr name="anonymousApiUserName"/>

--- a/android/library/src/main/res/values/attrs.xml
+++ b/android/library/src/main/res/values/attrs.xml
@@ -148,9 +148,9 @@
         <attr name="obcClassName"/>
     </declare-styleable>
 
-	<declare-styleable name="DDMFormScreenlet">
-		<attr name="formInstanceId"/>
-	</declare-styleable>
+    <declare-styleable name="DDMFormScreenlet">
+        <attr name="formInstanceId"/>
+    </declare-styleable>
 
     <declare-styleable name="ForgotPasswordScreenlet">
         <attr name="layoutId"/>

--- a/android/samples/test-app/src/main/java/com/liferay/mobile/screens/testapp/DDMFormActivity.java
+++ b/android/samples/test-app/src/main/java/com/liferay/mobile/screens/testapp/DDMFormActivity.java
@@ -22,6 +22,7 @@ import com.liferay.mobile.screens.base.ModalProgressBarWithLabel;
 import com.liferay.mobile.screens.ddm.form.DDMFormListener;
 import com.liferay.mobile.screens.ddm.form.DDMFormScreenlet;
 import com.liferay.mobile.screens.ddm.form.model.FormInstance;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Paulo Cruz
@@ -60,14 +61,14 @@ public class DDMFormActivity extends ThemeActivity implements DDMFormListener {
     }
 
     @Override
-    public void onFormLoaded(FormInstance formInstance) {
+    public void onFormLoaded(@NotNull FormInstance formInstance) {
         modalProgress.hide();
         screenlet.setVisibility(View.VISIBLE);
         info(getString(R.string.form_loaded_info));
     }
 
     @Override
-    public void onError(Exception exception) {
+    public void onError(@NotNull Exception exception) {
         info(getString(R.string.loading_form_error));
     }
 }

--- a/android/samples/test-app/src/main/java/com/liferay/mobile/screens/testapp/DDMFormActivity.java
+++ b/android/samples/test-app/src/main/java/com/liferay/mobile/screens/testapp/DDMFormActivity.java
@@ -28,46 +28,46 @@ import com.liferay.mobile.screens.ddm.form.model.FormInstance;
  */
 public class DDMFormActivity extends ThemeActivity implements DDMFormListener {
 
-	public static final String FORM_INSTANCE_ID_KEY = "FORM_INSTANCE_ID";
-	private DDMFormScreenlet screenlet;
-	private ModalProgressBarWithLabel modalProgress;
+    public static final String FORM_INSTANCE_ID_KEY = "FORM_INSTANCE_ID";
+    private DDMFormScreenlet screenlet;
+    private ModalProgressBarWithLabel modalProgress;
 
-	@Override
-	protected void onCreate(@Nullable Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		setContentView(R.layout.ddm_form);
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.ddm_form);
 
-		screenlet = findViewById(R.id.ddm_form_screenlet);
-		modalProgress = findViewById(R.id.liferay_modal_progress);
+        screenlet = findViewById(R.id.ddm_form_screenlet);
+        modalProgress = findViewById(R.id.liferay_modal_progress);
 
-		screenlet.setListener(this);
+        screenlet.setListener(this);
 
-		if (savedInstanceState == null) {
-			loadResource();
-		}
-	}
+        if (savedInstanceState == null) {
+            loadResource();
+        }
+    }
 
-	private void initScreenletFromIntent(Intent intent) {
-		if (intent.hasExtra(FORM_INSTANCE_ID_KEY)) {
-			screenlet.setFormInstanceId(intent.getLongExtra(FORM_INSTANCE_ID_KEY, 0));
-		}
-	}
+    private void initScreenletFromIntent(Intent intent) {
+        if (intent.hasExtra(FORM_INSTANCE_ID_KEY)) {
+            screenlet.setFormInstanceId(intent.getLongExtra(FORM_INSTANCE_ID_KEY, 0));
+        }
+    }
 
-	private void loadResource() {
-		screenlet.setVisibility(View.GONE);
-		modalProgress.show("Loading Form");
-		screenlet.load();
-	}
+    private void loadResource() {
+        screenlet.setVisibility(View.GONE);
+        modalProgress.show("Loading Form");
+        screenlet.load();
+    }
 
-	@Override
-	public void onFormLoaded(FormInstance formInstance) {
-		modalProgress.hide();
-		screenlet.setVisibility(View.VISIBLE);
-		info(getString(R.string.form_loaded_info));
-	}
+    @Override
+    public void onFormLoaded(FormInstance formInstance) {
+        modalProgress.hide();
+        screenlet.setVisibility(View.VISIBLE);
+        info(getString(R.string.form_loaded_info));
+    }
 
-	@Override
-	public void onError(Exception exception) {
-		info(getString(R.string.loading_form_error));
-	}
+    @Override
+    public void onError(Exception exception) {
+        info(getString(R.string.loading_form_error));
+    }
 }

--- a/android/samples/test-app/src/main/java/com/liferay/mobile/screens/testapp/DDMFormActivity.java
+++ b/android/samples/test-app/src/main/java/com/liferay/mobile/screens/testapp/DDMFormActivity.java
@@ -18,7 +18,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.View;
-
 import com.liferay.mobile.screens.base.ModalProgressBarWithLabel;
 import com.liferay.mobile.screens.ddm.form.DDMFormListener;
 import com.liferay.mobile.screens.ddm.form.DDMFormScreenlet;

--- a/android/samples/test-app/src/main/res/layout/ddm_form.xml
+++ b/android/samples/test-app/src/main/res/layout/ddm_form.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	android:orientation="vertical"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	>
 
-    <com.liferay.mobile.screens.thingscreenlet.screens.ThingScreenlet
+    <com.liferay.mobile.screens.thingscreenlet.screens.DDMFormScreenlet
         android:id="@+id/ddm_form_screenlet"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+	    app:formInstanceId="38105"
         />
 
     <com.liferay.mobile.screens.base.ModalProgressBarWithLabel

--- a/android/samples/test-app/src/main/res/layout/ddm_form.xml
+++ b/android/samples/test-app/src/main/res/layout/ddm_form.xml
@@ -6,11 +6,11 @@
 	android:layout_height="match_parent"
 	>
 
-    <com.liferay.mobile.screens.thingscreenlet.screens.DDMFormScreenlet
+    <com.liferay.mobile.screens.ddm.form.DDMFormScreenlet
         android:id="@+id/ddm_form_screenlet"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-	    app:formInstanceId="38105"
+	    app:formInstanceId="37105"
         />
 
     <com.liferay.mobile.screens.base.ModalProgressBarWithLabel

--- a/android/samples/test-app/src/main/res/layout/ddm_form.xml
+++ b/android/samples/test-app/src/main/res/layout/ddm_form.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:app="http://schemas.android.com/apk/res-auto"
-	android:orientation="vertical"
-	android:layout_width="match_parent"
-	android:layout_height="match_parent"
-	>
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
 
     <com.liferay.mobile.screens.ddm.form.DDMFormScreenlet
         android:id="@+id/ddm_form_screenlet"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-	    app:formInstanceId="37105"
+        app:formInstanceId="37105"
         />
 
     <com.liferay.mobile.screens.base.ModalProgressBarWithLabel

--- a/android/samples/test-app/src/main/res/layout/ddm_form.xml
+++ b/android/samples/test-app/src/main/res/layout/ddm_form.xml
@@ -18,7 +18,6 @@
         android:layout_height="match_parent"
         android:layout_width="match_parent"
         android:visibility="gone"
-        >
-    </com.liferay.mobile.screens.base.ModalProgressBarWithLabel>
+        />
 
 </FrameLayout>


### PR DESCRIPTION
As previously mentioned with @nhpatt we are adding a DDMFormScreenlet as a Wrapper for ThingScreenlet. There are three main reasons that I’ve thought to do this:
- Since `ThingScreenlet` means nothing for most of the people `DDMFormsScreenlet` seems much more portal user-friendly
- If this wrapper we can pass the formInstanceId in the XML, and also add new properties to make user customize Screenlet behavior
- It’s much more readable to write documentation for `DDMFormsScreenlet` than `ThingScreenlet`

